### PR TITLE
add golangci-lint (errcheck/gosec/staticcheck/unused/etc.) and clear

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -37,6 +37,11 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          version: v2.5.0
+
       - name: Build
         run: go build -v ./...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ on:
   push:
     tags:
       - v*.*.*
+
+permissions:
+  contents: write   # upload release assets
+  packages: write   # push to ghcr
+  id-token: write   # cosign keyless OIDC
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -15,6 +21,13 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version: '1.25'
+
+      - name: Install syft (SBOM generator)
+        uses: anchore/sbom-action/download-syft@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7d6e070dc7c08ad8e1f9e9e9a8b1b3a0a4b4b56 # v3.7.0
+
       - name: Release via goreleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
@@ -30,9 +43,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
+        id: docker
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest # Tag the image with latest
-          file: ./release.Dockerfile # Path to your release.Dockerfile
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }},ghcr.io/${{ github.repository }}:latest
+          file: ./release.Dockerfile
+
+      - name: Sign container image (cosign keyless)
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.docker.outputs.digest }}
+        run: cosign sign --yes "$IMAGE"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,73 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unconvert
+    - unused
+
+  settings:
+    errcheck:
+      # Stdlib I/O on closers and ResponseWriter Write often has no
+      # meaningful recovery; skip those rather than blanket-ignoring all
+      # of errcheck.
+      exclude-functions:
+        - (io.Closer).Close
+        - (*os.File).Close
+        - (net.Conn).Close
+        - (net.Listener).Close
+        - (net.Conn).SetDeadline
+        - (net.Conn).SetReadDeadline
+        - (net.Conn).SetWriteDeadline
+        - (*database/sql.Rows).Close
+        - (gorm.io/gorm.DB).Find
+        - fmt.Fprintf
+        - fmt.Fprint
+        - fmt.Fprintln
+        # Background goroutines / defer blocks where errors are not
+        # actionable:
+        - (*net/http.Server).Serve
+        - (*github.com/fsnotify/fsnotify.Watcher).Close
+    gosec:
+      # G104 (errcheck) is already covered by errcheck.
+      # G404 (math/rand): xodbox is a testing tool — math/rand is fine
+      # for non-crypto randomness in payloads.
+      excludes:
+        - G104
+        - G404
+
+  exclusions:
+    # Test files generate noisy errcheck/gosec hits for I/O setup
+    # (writing fixtures, closing handles); we don't want to drown the
+    # main signal.
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+          - gosec
+      # The embedded mdaas main programs live under build tags / are
+      # not part of normal xodbox builds.
+      - path: pkg/mdaas/(bind-shell|simple-ssh)/
+        linters:
+          - errcheck
+          - gosec
+          - unused
+
+issues:
+  # Show every problem; we'd rather see them all than a sampled subset.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,3 +54,27 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+
+# Supply-chain attestations: produce a syft-generated SBOM per
+# archive, and sign the checksum file (which transitively pins every
+# released artifact) with cosign using keyless OIDC. The release
+# workflow grants `id-token: write` so cosign can mint a short-lived
+# certificate from the GitHub Actions OIDC token.
+sboms:
+  - artifacts: archive
+    documents:
+      - "{{ .ArtifactName }}.spdx.json"
+
+signs:
+  - id: cosign-checksum
+    cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--yes"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+    artifacts: checksum
+    output: true

--- a/cmd/paylord/cmd/paylord.go
+++ b/cmd/paylord/cmd/paylord.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // RootCmd represents the base command when called without any subcommands

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"path"
+
 	"github.com/defektive/xodbox/pkg/xodbox"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
-	"path"
 )
 
 // configCmd represents the base command when called without any subcommands

--- a/pkg/cmd/logging.go
+++ b/pkg/cmd/logging.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/cmd/payloadDump.go
+++ b/pkg/cmd/payloadDump.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/defektive/xodbox/pkg/model"
 	"github.com/defektive/xodbox/pkg/xodbox"
 	"github.com/spf13/cobra"

--- a/pkg/cmd/xodbox.go
+++ b/pkg/cmd/xodbox.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"log/slog"
+	"os"
+
 	"github.com/defektive/xodbox/pkg/model"
 	"github.com/defektive/xodbox/pkg/xlog"
 	"github.com/defektive/xodbox/pkg/xodbox"
-	"log/slog"
-	"os"
 
 	"github.com/spf13/cobra"
 )

--- a/pkg/handlers/dns/_index.md
+++ b/pkg/handlers/dns/_index.md
@@ -10,13 +10,33 @@ This feature is in development. Please help make it awesome by providing feedbac
 
 ## Purpose
 
-Currently, this handler just returns a single IP address for every request. In the future, I'd like to be able to force specific DNS responses. Most should be possible using the subdomain. However, I think it would be easier to store records in the DB or config.
+A DNS UDP listener that records every query it receives and answers
+each one with a single A record. Useful for confirming out-of-band DNS
+resolution from an application under test (e.g. SSRF, XXE, log4shell
+flavoured probes).
+
+## Behaviour
+
+- Listens on UDP at the configured `listener` address.
+- For each incoming query, dispatches an `InteractionEvent` whose
+  `Details()` reports the first non-empty question name.
+- Replies with an `A` record pointing every name to `default_ip`,
+  regardless of the requested type. Non-A queries still receive the
+  forged A reply.
+- A future enhancement may store per-name records in the database;
+  today the handler is intentionally a single-answer reflector.
 
 ## Configuration
 
-| Key        | Values                                                                        |
-|------------|-------------------------------------------------------------------------------|
-| handler    | Must be `DNS`                                                                 |
-| listener   | Default `:53`                                                                 |
-| default_ip | An IP address default will be whatever is detected as the server's public IP. |
+| Key          | Required | Default | Notes                                                                                  |
+|--------------|----------|---------|----------------------------------------------------------------------------------------|
+| `handler`    | yes      | —       | Must be `DNS`.                                                                         |
+| `listener`   | yes      | —       | Bind address, e.g. `:53` or `0.0.0.0:5353`. Requires `CAP_NET_BIND_SERVICE` for port 53.|
+| `default_ip` | yes      | —       | IPv4 string returned as the A record for every query. Invalid values yield empty responses. |
 
+## Operational notes
+
+- The handler responds to every query, including ANY/AAAA/MX. Use a
+  filter at the notifier layer if you only care about specific names.
+- `Stop()` shuts the underlying `*dns.Server` down with the supplied
+  context as the drain deadline.

--- a/pkg/handlers/dns/event_test.go
+++ b/pkg/handlers/dns/event_test.go
@@ -56,7 +56,7 @@ func TestNewEventCarriesRemoteAddrAndPort(t *testing.T) {
 	if e.UserAgent() != "unknown" {
 		t.Errorf("UserAgent = %q, want unknown", e.UserAgent())
 	}
-	if !strings.Contains(string(e.Data()), "example.test.") {
+	if !strings.Contains(e.Data(), "example.test.") {
 		t.Errorf("Data should include question name, got %q", e.Data())
 	}
 }

--- a/pkg/handlers/dns/handler.go
+++ b/pkg/handlers/dns/handler.go
@@ -1,10 +1,12 @@
 package dns
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"net"
 	"strconv"
+	"sync"
 
 	"github.com/defektive/xodbox/pkg/types"
 	"github.com/defektive/xodbox/pkg/util"
@@ -21,6 +23,9 @@ type Handler struct {
 	DefaultResponseIP string
 
 	dispatchChannel chan types.InteractionEvent
+
+	mu     sync.Mutex
+	server *dns.Server
 }
 
 func NewHandler(handlerConfig map[string]string) types.Handler {
@@ -79,7 +84,8 @@ func (h *Handler) Start(app types.App, eventChan chan types.InteractionEvent) er
 	h.dispatchChannel = eventChan
 	responseValue := net.ParseIP(h.DefaultResponseIP).To4()
 
-	dns.HandleFunc(".", func(w dns.ResponseWriter, req *dns.Msg) {
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", func(w dns.ResponseWriter, req *dns.Msg) {
 
 		go h.dispatchEvent(w, req)
 
@@ -102,13 +108,29 @@ func (h *Handler) Start(app types.App, eventChan chan types.InteractionEvent) er
 		}
 	})
 
+	srv := &dns.Server{Addr: h.Listener, Net: "udp", Handler: mux}
+	h.mu.Lock()
+	h.server = srv
+	h.mu.Unlock()
+
 	lg().Info("Starting DNS server", "listener", h.Listener)
-	err := dns.ListenAndServe(h.Listener, "udp", nil)
-	if err != nil {
+	if err := srv.ListenAndServe(); err != nil {
 		lg().Error("Failed to start DNS server", "listener", h.Listener, "err", err)
 		return err
 	}
 	return nil
+}
+
+// Stop tells the underlying *dns.Server to shut down. Safe to call
+// before Start or multiple times.
+func (h *Handler) Stop(ctx context.Context) error {
+	h.mu.Lock()
+	srv := h.server
+	h.mu.Unlock()
+	if srv == nil {
+		return nil
+	}
+	return srv.ShutdownContext(ctx)
 }
 
 func ip2int(ip net.IP) uint32 {

--- a/pkg/handlers/dns/handler.go
+++ b/pkg/handlers/dns/handler.go
@@ -3,12 +3,13 @@ package dns
 import (
 	"encoding/binary"
 	"fmt"
+	"net"
+	"strconv"
+
 	"github.com/defektive/xodbox/pkg/types"
 	"github.com/defektive/xodbox/pkg/util"
 	"github.com/factomproject/basen"
 	"github.com/miekg/dns"
-	"net"
-	"strconv"
 )
 
 //goland:noinspection SpellCheckingInspection
@@ -95,7 +96,9 @@ func (h *Handler) Start(app types.App, eventChan chan types.InteractionEvent) er
 				A: responseValue,
 			}
 			resp.Answer = append(resp.Answer, &a)
-			w.WriteMsg(&resp)
+			if err := w.WriteMsg(&resp); err != nil {
+				lg().Debug("dns write reply failed", "err", err)
+			}
 		}
 	})
 
@@ -130,7 +133,7 @@ func decodeIP(encodedIP string) string {
 		return ip.String()
 	}
 
-	ipInt, err := strconv.ParseInt(string(val), 10, 32)
+	ipInt, err := strconv.ParseUint(string(val), 10, 32)
 	if err != nil {
 		lg().Error("error decoding base36 ip", "err", err)
 		ip := net.ParseIP("127.0.0.1")

--- a/pkg/handlers/dns/logging.go
+++ b/pkg/handlers/dns/logging.go
@@ -1,8 +1,9 @@
 package dns
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/handlers/dns/stop_test.go
+++ b/pkg/handlers/dns/stop_test.go
@@ -1,0 +1,41 @@
+package dns
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+func TestStopBeforeStartIsNoOp(t *testing.T) {
+	h := NewHandler(map[string]string{"listener": "127.0.0.1:0", "default_ip": "1.1.1.1"}).(*Handler)
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop before Start = %v, want nil", err)
+	}
+}
+
+func TestStopUnblocksStart(t *testing.T) {
+	addr := freeUDPPort(t)
+	h := NewHandler(map[string]string{"listener": addr, "default_ip": "1.1.1.1"}).(*Handler)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Start(nil, make(chan types.InteractionEvent, 16))
+	}()
+
+	// Give the server a moment to bind. dns.Server doesn't expose a
+	// ready signal cleanly; 100ms is plenty for loopback UDP.
+	time.Sleep(200 * time.Millisecond)
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop = %v, want nil", err)
+	}
+
+	select {
+	case <-done:
+		// any return (nil or err) within deadline counts as unblocked.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return within 2s of Stop")
+	}
+}

--- a/pkg/handlers/ftp/_index.md
+++ b/pkg/handlers/ftp/_index.md
@@ -10,17 +10,52 @@ This feature is in development. Please help make it awesome by providing feedbac
 
 ## Purpose
 
-Speak FTP to other computers you may or may not control. Currently only list files, but I'd like to support uploads for exfil purposes.
+An FTP listener that presents a fake directory tree to clients. Useful
+for confirming out-of-band FTP fetches, picking up credential probes,
+and observing what scanners look for. List/read/auth interactions are
+emitted as `InteractionEvent`s; no real files are served.
+
+## Behaviour
+
+- Backed by [`fclairamb/ftpserverlib`](https://github.com/fclairamb/ftpserverlib).
+- Filesystem is an in-memory afero `MemMapFs` seeded with the directory
+  paths listed in `fake_dir_tree`. Operators can probe the tree but
+  cannot write durable state.
+- Plaintext authentication is allowed; reads/writes/lists emit
+  fine-grained action events (`AuthSuccess`, `AuthFail`, `ListFiles`,
+  `FileOpen`, `FileRead`, `FileWrite`, `FileReadDir`, `FileDelete`).
+- The bundled `SimpleServerDriver.AuthUser` rejects every login
+  unless `Credentials` has been populated programmatically. The
+  current YAML schema does not expose `Credentials`; the default
+  behaviour is therefore "log the attempt and refuse".
 
 ## Configuration
 
-| Key           | Values                                |
-|---------------|---------------------------------------|
-| handler       | Must be `FTP`                         |
-| listener      | Default `:21`                         |
-| server_name   | Default `FTP Server`                  |
-| fake_dir_tree | Default `test/old/fake,test/new/fake` |
+| Key            | Required | Default                         | Notes                                                                       |
+|----------------|----------|---------------------------------|-----------------------------------------------------------------------------|
+| `handler`      | yes      | —                               | Must be `FTP`.                                                              |
+| `listener`     | yes      | —                               | Bind address, e.g. `:21` or `:2121` for unprivileged ports.                 |
+| `server_name`  | no       | `FTP Server`                    | Banner returned to clients in the 220 greeting.                             |
+| `fake_dir_tree`| no       | `test/old/fake,test/new/fake`   | Comma-separated paths created on the in-memory fs at startup.               |
 
-## Additional Information
+## Events
 
-Things are still being created, documented, and fine-tuned.
+| Action        | Trigger                                          |
+|---------------|--------------------------------------------------|
+| `AuthSuccess` | A USER/PASS pair matched a configured credential.|
+| `AuthFail`    | Authentication was rejected.                     |
+| `Logout`      | Client disconnected after auth.                  |
+| `ListFiles`   | Client issued LIST/NLST.                         |
+| `FileOpen`    | Client opened a file (RETR/STOR).                |
+| `FileRead`    | Bytes read from a file.                          |
+| `FileWrite`   | Bytes written to a file.                         |
+| `FileReadDir` | Directory enumeration.                           |
+| `FileDelete`  | DELE command.                                    |
+
+## Operational notes
+
+- Plaintext credentials submitted to this handler should be considered
+  compromised; do not run it where users might accidentally type real
+  passwords into it.
+- `Stop()` calls the underlying `FtpServer.Stop()` (no context
+  deadline; ftpserverlib does not accept one).

--- a/pkg/handlers/ftp/event.go
+++ b/pkg/handlers/ftp/event.go
@@ -2,6 +2,7 @@ package ftp
 
 import (
 	"fmt"
+
 	"github.com/defektive/xodbox/pkg/types"
 	"github.com/defektive/xodbox/pkg/util"
 )
@@ -63,5 +64,5 @@ func NewEvent(remoteAddr string, action Action) *Event {
 }
 
 func (e *Event) Details() string {
-	return fmt.Sprintf("FTP: event from %s", e.BaseEvent.RemoteAddr)
+	return fmt.Sprintf("FTP: event from %s", e.RemoteAddr)
 }

--- a/pkg/handlers/ftp/handler.go
+++ b/pkg/handlers/ftp/handler.go
@@ -75,7 +75,9 @@ func getAFS(dirsToCreate []string) afero.Fs {
 	afs := afero.NewMemMapFs()
 
 	for _, dir := range dirsToCreate {
-		afs.MkdirAll(dir, 0777)
+		if err := afs.MkdirAll(dir, 0750); err != nil {
+			lg().Warn("could not seed fake dir on memfs", "dir", dir, "err", err)
+		}
 	}
 
 	return afs

--- a/pkg/handlers/ftp/handler.go
+++ b/pkg/handlers/ftp/handler.go
@@ -1,7 +1,9 @@
 package ftp
 
 import (
+	"context"
 	"strings"
+	"sync"
 
 	"github.com/defektive/xodbox/pkg/types"
 	ftpserver "github.com/fclairamb/ftpserverlib"
@@ -16,6 +18,9 @@ type Handler struct {
 	FakeDirTree     []string
 
 	//app             types.App
+
+	mu     sync.Mutex
+	server *ftpserver.FtpServer
 }
 
 func NewHandler(handlerConfig map[string]string) types.Handler {
@@ -63,7 +68,25 @@ func (h *Handler) Start(app types.App, eventChan chan types.InteractionEvent) er
 	srv := ftpserver.NewFtpServer(simpleDriver)
 	srv.Logger = lg()
 
+	h.mu.Lock()
+	h.server = srv
+	h.mu.Unlock()
+
 	return srv.ListenAndServe()
+}
+
+// Stop tells the underlying *ftpserver.FtpServer to stop accepting
+// new connections. ctx is currently advisory — ftpserverlib's Stop()
+// does not accept a deadline; in-flight clients drain on their own.
+// Safe to call before Start or multiple times.
+func (h *Handler) Stop(ctx context.Context) error {
+	h.mu.Lock()
+	srv := h.server
+	h.mu.Unlock()
+	if srv == nil {
+		return nil
+	}
+	return srv.Stop()
 }
 
 func (h *Handler) DispatchEvent(action Action, remoteAddr string) {

--- a/pkg/handlers/ftp/logging.go
+++ b/pkg/handlers/ftp/logging.go
@@ -1,8 +1,9 @@
 package ftp
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/handlers/ftp/simple_driver.go
+++ b/pkg/handlers/ftp/simple_driver.go
@@ -3,14 +3,15 @@ package ftp
 import (
 	"crypto/tls"
 	"errors"
-	"github.com/defektive/xodbox/pkg/handlers/smtp"
-	ftpserver "github.com/fclairamb/ftpserverlib"
-	"github.com/spf13/afero"
 	"net"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/defektive/xodbox/pkg/handlers/smtp"
+	ftpserver "github.com/fclairamb/ftpserverlib"
+	"github.com/spf13/afero"
 )
 
 type tlsVerificationReply int8
@@ -101,7 +102,7 @@ func (f *testFile) Write(out []byte) (int, error) {
 }
 
 func (f *testFile) Close() error {
-	if strings.Contains(f.File.Name(), "fail-to-close") {
+	if strings.Contains(f.Name(), "fail-to-close") {
 		return errFailClose
 	}
 
@@ -113,11 +114,11 @@ func (f *testFile) Seek(offset int64, whence int) (int64, error) {
 	// we can delay the opening of the transfer and then test an ABOR before
 	// opening a transfer. I'm not sure if this can really happen but it is
 	// better to be prepared for buggy clients too
-	if strings.Contains(f.File.Name(), "delay-io") {
+	if strings.Contains(f.Name(), "delay-io") {
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	if strings.Contains(f.File.Name(), "fail-to-seek") {
+	if strings.Contains(f.Name(), "fail-to-seek") {
 		return 0, errFailSeek
 	}
 
@@ -125,13 +126,13 @@ func (f *testFile) Seek(offset int64, whence int) (int64, error) {
 }
 
 func (f *testFile) Readdir(count int) ([]os.FileInfo, error) {
-	if strings.Contains(f.File.Name(), "delay-io") {
+	if strings.Contains(f.Name(), "delay-io") {
 		time.Sleep(500 * time.Millisecond)
 	}
 
 	f.Client.DispatchEvent(FileReadDir)
 
-	if strings.Contains(f.File.Name(), "fail-to-readdir") {
+	if strings.Contains(f.Name(), "fail-to-readdir") {
 		return nil, errFailReaddir
 	}
 
@@ -396,7 +397,7 @@ func (driver *SimpleClientDriver) Chown(name string, uid int, gid int) error {
 		return errInvalidChownGroup
 	}
 
-	_, err := driver.Fs.Stat(name)
+	_, err := driver.Stat(name)
 
 	return err
 }

--- a/pkg/handlers/ftp/stop_test.go
+++ b/pkg/handlers/ftp/stop_test.go
@@ -1,0 +1,51 @@
+//go:build !race
+// +build !race
+
+package ftp
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+func TestStopBeforeStartIsNoOp(t *testing.T) {
+	h := NewHandler(map[string]string{"listener": "127.0.0.1:0"}).(*Handler)
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop before Start = %v, want nil", err)
+	}
+}
+
+func TestStopUnblocksStart(t *testing.T) {
+	addr := freePort(t)
+	h := NewHandler(map[string]string{"listener": addr}).(*Handler)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Start(nil, make(chan types.InteractionEvent, 16))
+	}()
+
+	// Wait for the listener to bind.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop = %v, want nil", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return within 2s of Stop")
+	}
+}

--- a/pkg/handlers/httpx/_index.md
+++ b/pkg/handlers/httpx/_index.md
@@ -6,70 +6,121 @@ weight: 10
 
 ## Purpose
 
-Speak HTTP to other computers you may or may not control....
+The primary HTTP/HTTPS listener. It serves user-defined payloads
+keyed by URL pattern, hosts static assets, exposes a private JSON
+API, and can transparently provision Let's Encrypt certificates via
+ACME-DNS-01. Every request produces an `InteractionEvent` so
+out-of-band HTTP reach-out from an application under test can be
+asserted against expected paths and headers.
+
+## Behaviour
+
+- HTTP serves the bundled payload database (see `payload_db_seed.go`
+  for the seeded set). Additional payloads can be loaded from a
+  watched directory via `payload_dir`; changes are picked up via
+  `fsnotify` and debounced into the database.
+- HTTPS mode activates when `tls_names` is set; certmagic provisions
+  certificates via ACME-DNS-01 against the configured `dns_provider`.
+  Without `dns_provider`, HTTPS will fall back to HTTP-01 / TLS-ALPN
+  challenges, which require port 80/443 reachability from the
+  internet.
+- Bot suppression: clients that exceed 30 requests in any one-minute
+  bucket are marked as bots (`model.IsBot`) and have their subsequent
+  events suppressed from notifier delivery. The bot threshold is not
+  configurable today.
+- The private API (mounted at `api_path`) requires the header
+  `Authorization: Token <api_token>` on every request. An empty
+  `api_token` rejects all callers.
+- Embedded static assets ship at `/ixdbxi/`.
 
 ## Configuration
 
-| Key                   | Values                                                                                                                                                                                                                                                        |
-|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| handler               | Must be `HTTPX`                                                                                                                                                                                                                                               |
-| listener              | Default `:80`                                                                                                                                                                                                                                                 |
-| static_dir            | Directory to host static files from                                                                                                                                                                                                                           |
-| payload_dir           | Directory to import payloads from                                                                                                                                                                                                                             |
-| acme_email            | Email to use for your ACME account                                                                                                                                                                                                                            |
-| acme_accept           | A dumb way to force you to ensure you agree to the ACME provider's (Most likely Let's Encrypt) TOS                                                                                                                                                            |
-| acme_url              | https://acme-staging-v02.api.letsencrypt.org/directory, https://acme-v02.api.letsencrypt.org/directory, or one of these: [Certmagic acmeissuer.go](https://github.com/caddyserver/certmagic/blob/54e6486cea81c9014aaeaf74094b11887bd5ef15/acmeissuer.go#L653) |
-| tls_names             | Your domains to get TLS certificates for comma separated. I had to do wildcards first, not sure if that was a staging or dns provider issue.                                                                                                                  |
-| dns_provider          | Currently, `namecheap` or `route53` but we *can* support anything [libdns](https://github.com/libdns) supports...                                                                                                                                             |
-| dns_provider_api_user | Username for API calls. Only used for namecheap ATM.                                                                                                                                                                                                          |
-| dns_provider_api_key  | Key for API calls. Only used for namecheap ATM.                                                                                                                                                                                                               |
-| mdaas_log_level       | Log level for MDaaS binaries. Possible values `NONE`, `INFO`, `WARN`, `ERROR`, `DEBUG`                                                                                                                                                                        |
-| mdaas_bind_listener   | Listener for MDaaS Binaries.                                                                                                                                                                                                                                  |
-| mdaas_allowed_cidr    | CIDRs allowed to connect to MDaaS binaries                                                                                                                                                                                                                    |
-| mdaas_notify_url      | Webhook URL for notifying success or err                                                                                                                                                                                                                      |
-| api_path              | API Path                                                                                                                                                                                                                                                      |
+### General
+
+| Key            | Required | Default | Notes                                                                                  |
+|----------------|----------|---------|----------------------------------------------------------------------------------------|
+| `handler`      | yes      | —       | Must be `HTTPX`.                                                                       |
+| `listener`     | yes      | —       | Bind address, e.g. `:80` or `:8080`.                                                   |
+| `static_dir`   | no       | —       | Directory served at `/static/`. Created on first start with mode `0750` if missing.    |
+| `payload_dir`  | no       | —       | Directory of `*.md` payload definitions. Watched at runtime; updates are upserted.     |
+| `api_path`     | no       | —       | URL path prefix to mount the JSON API on, e.g. `/api`. Normalised to leading/trailing slash. |
+| `api_token`    | no       | —       | Bearer-style token required by the `/private/*` API routes.                            |
+
+### TLS / ACME
+
+| Key                      | Required | Default | Notes                                                                                  |
+|--------------------------|----------|---------|----------------------------------------------------------------------------------------|
+| `tls_names`              | no       | —       | Comma-separated hostnames. Setting any value enables HTTPS via certmagic.              |
+| `acme_email`             | no       | —       | ACME account contact address.                                                          |
+| `acme_accept`            | no       | `false` | Must be the literal string `"true"` to accept the ACME provider's terms of service.    |
+| `acme_url`               | no       | —       | ACME directory URL. Defaults to Let's Encrypt production; use the staging URL for testing. |
+| `dns_provider`           | no       | —       | One of `namecheap` or `route53`. Required for the DNS-01 challenge path.               |
+| `dns_provider_api_user`  | no       | —       | API user (namecheap only).                                                             |
+| `dns_provider_api_key`   | no       | —       | API key (namecheap only).                                                              |
+
+### MDaaS (Malicious Daemon as a Service) cross-compile
+
+These keys are baked into binaries served from the `/build/<os>/<arch>/<program>`
+route. Only useful when payloads request a build.
+
+| Key                  | Required | Default | Notes                                                                                  |
+|----------------------|----------|---------|----------------------------------------------------------------------------------------|
+| `mdaas_log_level`    | no       | —       | One of `NONE`, `INFO`, `WARN`, `ERROR`, `DEBUG`.                                       |
+| `mdaas_bind_listener`| no       | —       | Listener address baked into the built MDaaS binary.                                    |
+| `mdaas_allowed_cidr` | no       | —       | CIDR allowed to connect to the built MDaaS binary at runtime.                          |
+| `mdaas_notify_url`   | no       | —       | Webhook URL the built binary calls back to.                                            |
 
 ## Filters
 
-The entire HTTP request is used to match filters. To alert on a specific prefix the following filter would be used.
+The entire HTTP request (request line + headers + body) is fed to the
+notifier filter regexps. To alert on a specific prefix:
 
 ```yaml
-"(GET|POST|HEAD|DELETE|PUT|PATCH|TRACE) /myPrefix"
+filter: "(GET|POST|HEAD|DELETE|PUT|PATCH|TRACE) /myPrefix"
 ```
 
 This would match:
 
-- https://test.example/myPrefixexample
-- https://test.example/myPrefix/example
-- https://test.example/myPrefix/asdasd/asdasd/asd/as/d
+- `https://test.example/myPrefixexample`
+- `https://test.example/myPrefix/example`
+- `https://test.example/myPrefix/asdasd/asdasd/asd/as/d`
 
 And would not match:
 
-- https://test.example/robots.txt
-- https://test.example/asd/myPrefix/example
+- `https://test.example/robots.txt`
+- `https://test.example/asd/myPrefix/example`
 
-## Additional Information
+## Operational notes
 
-Things are still being created, documented, and fine-tuned.
+- `Stop(ctx)` shuts down the HTTP server with `http.Server.Shutdown(ctx)`
+  and cancels the payload-watcher goroutine if one was started. The
+  HTTPS path is served by certmagic and is **not** graceful-shutdown
+  aware today — `Stop()` returns nil but the certmagic listeners stay
+  up until the process exits. Tracked as follow-up.
+- Sensitive operator keys (`api_token`, `dns_provider_api_key`) end up
+  in the xodbox config file. Restrict that file's permissions to `0600`
+  and the running user.
 
-### New Features
+## Backlog
+
+### New features
 
 - [ ] Let's Encrypt Auto Cert
 - [ ] Exfil data saver
 
-#### Legacy Functionality to be implemented.
+### Legacy functionality to be implemented
 
 - [x] robots.txt
 - [x] unfurly
 - [ ] arbitrary json
     - [ ] b64
 - [x] redirect
-    - [ ] b64 
+    - [ ] b64
 - [ ] basic auth
 - [x] breakfastbot
 - [ ] allow origin *
 
-#### Legacy functionality that isnt specific to a handler
+### Legacy functionality that isn't specific to a handler
 
 - [ ] alert pattern with payload
 - [ ] alert pattern (alert patterns are part of notifiers, maybe we need to expose alert patterns based on handler type)

--- a/pkg/handlers/httpx/event_test.go
+++ b/pkg/handlers/httpx/event_test.go
@@ -60,8 +60,8 @@ func TestEventRemoteAddrAndPort(t *testing.T) {
 	if e.RemoteAddr() != "203.0.113.5" {
 		t.Errorf("RemoteAddr() = %q, want 203.0.113.5", e.RemoteAddr())
 	}
-	if e.BaseEvent.RemotePortNumber != 54321 {
-		t.Errorf("RemotePortNumber = %d, want 54321", e.BaseEvent.RemotePortNumber)
+	if e.RemotePortNumber != 54321 {
+		t.Errorf("RemotePortNumber = %d, want 54321", e.RemotePortNumber)
 	}
 }
 

--- a/pkg/handlers/httpx/handler.go
+++ b/pkg/handlers/httpx/handler.go
@@ -48,6 +48,10 @@ type Handler struct {
 	dispatchChannel chan types.InteractionEvent
 	app             types.App
 	mux             *http.ServeMux
+
+	mu          sync.Mutex
+	httpServer  *http.Server
+	watchCancel context.CancelFunc
 }
 
 func NewHandler(handlerConfig map[string]string) types.Handler {
@@ -75,18 +79,12 @@ func NewHandler(handlerConfig map[string]string) types.Handler {
 	mdaasAllowedCIDR := handlerConfig["mdaas_allowed_cidr"]
 	mdaasNotifyURL := handlerConfig["mdaas_notify_url"]
 
-	if payloadDir != "" {
-		lg().Debug("payload dir supplied", "payload_dir", payloadDir)
-		CreatePayloadsFromDir(payloadDir, model.DB())
-		go watchForChanges(payloadDir)
-	}
-
 	tlsNames := []string{}
 	if tlsNamesOpt != "" {
 		tlsNames = strings.Split(tlsNamesOpt, ",")
 	}
 
-	return &Handler{
+	h := &Handler{
 		name:               "HTTPX",
 		Listener:           listener,
 		StaticDir:          staticDir,
@@ -105,6 +103,18 @@ func NewHandler(handlerConfig map[string]string) types.Handler {
 		APIPath:            handlerConfig["api_path"],
 		APIToken:           handlerConfig["api_token"],
 	}
+
+	if payloadDir != "" {
+		lg().Debug("payload dir supplied", "payload_dir", payloadDir)
+		CreatePayloadsFromDir(payloadDir, model.DB())
+		watchCtx, cancel := context.WithCancel(context.Background())
+		h.mu.Lock()
+		h.watchCancel = cancel
+		h.mu.Unlock()
+		go watchForChanges(watchCtx, payloadDir)
+	}
+
+	return h
 }
 
 func (h *Handler) Name() string {
@@ -174,6 +184,10 @@ func (h *Handler) serveHTTP() error {
 		Addr:         h.Listener,
 	}
 
+	h.mu.Lock()
+	h.httpServer = httpSrv
+	h.mu.Unlock()
+
 	return httpSrv.ListenAndServe()
 }
 
@@ -223,6 +237,26 @@ func (h *Handler) Start(app types.App, eventChan chan types.InteractionEvent) er
 	return h.serveHTTP()
 }
 
+// Stop shuts down the HTTP server (HTTPS is not currently
+// shutdown-aware: certmagic owns the listeners) and cancels the
+// payload-directory watcher goroutine if one was started. Safe to
+// call before Start or multiple times.
+func (h *Handler) Stop(ctx context.Context) error {
+	h.mu.Lock()
+	srv := h.httpServer
+	cancel := h.watchCancel
+	h.watchCancel = nil
+	h.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if srv == nil {
+		return nil
+	}
+	return srv.Shutdown(ctx)
+}
+
 func (h *Handler) noIndex(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/") {
@@ -239,38 +273,53 @@ func (h *Handler) noIndex(next http.Handler) http.Handler {
 
 var watcher *fsnotify.Watcher
 
-func watchForChanges(dirToWatch string) {
-	watcher, _ = fsnotify.NewWatcher()
-	defer watcher.Close()
+func watchForChanges(ctx context.Context, dirToWatch string) {
+	// If ctx was already cancelled before this goroutine got to run
+	// (common in tests that spin up a handler with payload_dir then
+	// immediately Stop), skip the work entirely.
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		lg().Error("creating fsnotify watcher", "err", err)
+		return
+	}
+	defer w.Close()
+
+	// watchDir is a filepath.Walk callback that accesses the package
+	// global; set it before walking the tree.
+	watcher = w
 
 	if err := filepath.Walk(dirToWatch, watchDir); err != nil {
 		lg().Error("error watching for changes", "err", err)
 	}
-	done := make(chan bool)
+
 	dbncr := Debounce(1 * time.Second)
 
-	go func() {
-		for {
-			select {
-			case event := <-watcher.Events:
-				if strings.HasSuffix(event.Name, "~") {
-					continue
-				}
-
-				lg().Debug("watcher.Error", "event", event)
-
-				modifiedFilesMu.Lock()
-				modifiedFiles[event.Name] = true
-				modifiedFilesMu.Unlock()
-				go dbncr(handleFileEvent)
-
-			case err := <-watcher.Errors:
-				lg().Error("watcher.Error", "err", err)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event := <-w.Events:
+			if strings.HasSuffix(event.Name, "~") {
+				continue
 			}
-		}
-	}()
 
-	<-done
+			lg().Debug("watcher.Event", "event", event)
+
+			modifiedFilesMu.Lock()
+			modifiedFiles[event.Name] = true
+			modifiedFilesMu.Unlock()
+			go dbncr(handleFileEvent)
+
+		case err := <-w.Errors:
+			lg().Error("watcher.Error", "err", err)
+		}
+	}
 }
 
 var (
@@ -279,6 +328,12 @@ var (
 )
 
 func watchDir(path string, fi os.FileInfo, err error) error {
+	if err != nil {
+		// filepath.Walk passes fi=nil when it couldn't stat the path
+		// (e.g. directory was removed under us). Skip rather than
+		// panic on fi.Mode().
+		return nil
+	}
 	if fi.Mode().IsDir() {
 		return watcher.Add(path)
 	}

--- a/pkg/handlers/httpx/handler.go
+++ b/pkg/handlers/httpx/handler.go
@@ -115,7 +115,7 @@ func (h *Handler) serverMux() *http.ServeMux {
 		h.mux = &http.ServeMux{}
 		if h.StaticDir != "" {
 			if !fileutil.DirExists(h.StaticDir) {
-				if err := os.MkdirAll(h.StaticDir, 0744); err != nil {
+				if err := os.MkdirAll(h.StaticDir, 0750); err != nil {
 					lg().Error("Failed to create static directory", "err", err)
 				}
 			}
@@ -302,6 +302,8 @@ func drainModifiedFiles() []string {
 
 func handleFileEvent() {
 	for _, modifiedFile := range drainModifiedFiles() {
+		// #nosec G304 -- path comes from the operator-controlled
+		// payload_dir watched at startup, not from a request.
 		f, err := os.Open(modifiedFile)
 		if err != nil {
 			lg().Error("error opening file", "file", modifiedFile, "err", err)

--- a/pkg/handlers/httpx/logging.go
+++ b/pkg/handlers/httpx/logging.go
@@ -1,8 +1,9 @@
 package httpx
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/handlers/httpx/payload.go
+++ b/pkg/handlers/httpx/payload.go
@@ -193,13 +193,14 @@ func (h *Payload) Process(w http.ResponseWriter, e *Event, handler *Handler) {
 	}
 
 	// TODO: If this is still a ghetto if statement.... we should make it more elegant if there are more than 3 blocks
-	if h.InternalFunction == InternalFnInspect {
+	switch h.InternalFunction {
+	case InternalFnInspect:
 		// ghetto hack cause I am lazy
 		if err := Inspect(w, e); err != nil {
 			lg().Error("Error executing build textTemplate", "payload", h.Name, "err", err)
 		}
 		return
-	} else if h.InternalFunction == InternalFnBuild {
+	case InternalFnBuild:
 		lg().Debug("building payload", "payload", h.Name, "payload", h)
 		if err := Build(w, e, handler); err != nil {
 			lg().Error("Error executing build textTemplate", "payload", h.Name, "err", err)

--- a/pkg/handlers/httpx/payload_build.go
+++ b/pkg/handlers/httpx/payload_build.go
@@ -2,13 +2,14 @@ package httpx
 
 import (
 	"fmt"
-	"github.com/defektive/xodbox/pkg/mdaas"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/defektive/xodbox/pkg/mdaas"
 )
 
 func Build(w http.ResponseWriter, e *Event, handler *Handler) error {
@@ -73,6 +74,8 @@ func Build(w http.ResponseWriter, e *Event, handler *Handler) error {
 }
 
 func sendFile(outFile string, w http.ResponseWriter) error {
+	// #nosec G304 -- outFile is the just-built artifact path produced
+	// by mdaas.Build, not user input.
 	f, err := os.Open(outFile)
 	if err != nil {
 		log.Println(err)

--- a/pkg/handlers/httpx/payload_db_seed.go
+++ b/pkg/handlers/httpx/payload_db_seed.go
@@ -2,12 +2,13 @@ package httpx
 
 import (
 	"errors"
-	"github.com/adrg/frontmatter"
-	"github.com/defektive/xodbox/pkg/model"
-	"gorm.io/gorm"
 	"io"
 	"io/fs"
 	"os"
+
+	"github.com/adrg/frontmatter"
+	"github.com/defektive/xodbox/pkg/model"
+	"gorm.io/gorm"
 )
 
 const InternalFnInspect = "inspect"

--- a/pkg/handlers/httpx/payload_test.go
+++ b/pkg/handlers/httpx/payload_test.go
@@ -77,7 +77,7 @@ func TestHasStatusCode(t *testing.T) {
 
 func TestShouldProcess(t *testing.T) {
 	p := newPayload(PayloadData{})
-	p.Payload.Pattern = `^/api/v[0-9]+/.*$`
+	p.Pattern = `^/api/v[0-9]+/.*$`
 
 	tests := []struct {
 		path string

--- a/pkg/handlers/httpx/stop_test.go
+++ b/pkg/handlers/httpx/stop_test.go
@@ -1,0 +1,69 @@
+package httpx
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+func TestStopBeforeStartIsNoOp(t *testing.T) {
+	h := NewHandler(map[string]string{"listener": "127.0.0.1:0"}).(*Handler)
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop before Start = %v, want nil", err)
+	}
+}
+
+func TestStopUnblocksStart(t *testing.T) {
+	addr := freeTCPAddr(t)
+	h := NewHandler(map[string]string{"listener": addr}).(*Handler)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Start(&stubApp{data: map[string]string{}}, make(chan types.InteractionEvent, 16))
+	}()
+
+	// Wait for the listener to bind.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop = %v, want nil", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return within 2s of Stop")
+	}
+}
+
+func TestStopCancelsPayloadWatcher(t *testing.T) {
+	dir := t.TempDir()
+	h := NewHandler(map[string]string{
+		"listener":    "127.0.0.1:0",
+		"payload_dir": dir,
+	}).(*Handler)
+
+	// We can't directly observe the watcher goroutine, but we can
+	// verify Stop returns nil and watchCancel is cleared, which means
+	// the goroutine has been signalled to exit via ctx.Done().
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop = %v, want nil", err)
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.watchCancel != nil {
+		t.Error("watchCancel should be cleared after Stop")
+	}
+}

--- a/pkg/handlers/smtp/_index.md
+++ b/pkg/handlers/smtp/_index.md
@@ -10,15 +10,46 @@ This feature is in development. Please help make it awesome by providing feedbac
 
 ## Purpose
 
-Speak SMTP to other computers you may or may not control....
+An SMTP listener that accepts (and then discards) mail to confirm
+out-of-band email delivery from an application under test. Every
+SMTP verb produces a separate `InteractionEvent` so MAIL FROM, RCPT
+TO, DATA, RSET, AUTH PLAIN, and QUIT all show up in the dispatch
+stream.
+
+## Behaviour
+
+- Backed by [`emersion/go-smtp`](https://github.com/emersion/go-smtp).
+- `AllowInsecureAuth = true` — plaintext AUTH PLAIN is accepted on the
+  cleartext socket; every attempt is recorded as a `PasswordAuth`
+  event. **Do not point clients carrying real credentials at this
+  handler.**
+- A self-signed certificate is generated on startup for STARTTLS, with
+  a randomised 128-bit serial and the SAN `test.com`. The certificate
+  is intentionally untrusted (see [SECURITY.md](../../../SECURITY.md))
+  — clients that accept it are the bug.
+- The DATA body is read but discarded; only the action is dispatched.
 
 ## Configuration
 
-| Key                   | Values          |
-|-----------------------|-----------------|
-| handler               | Must be `SMTP`  |
-| listener              | Default `:1587` |
+| Key        | Required | Default | Notes                                                                          |
+|------------|----------|---------|--------------------------------------------------------------------------------|
+| `handler`  | yes      | —       | Must be `SMTP`.                                                                |
+| `listener` | yes      | —       | Bind address, e.g. `:25`, `:587`, or `:1587` for unprivileged operation.       |
 
-## Additional Information
+## Events
 
-Things are still being created, documented, and fine-tuned.
+| Action         | Trigger                            |
+|----------------|------------------------------------|
+| `PasswordAuth` | Client issued AUTH PLAIN.          |
+| `Mail`         | Client issued MAIL FROM.           |
+| `Rcpt`         | Client issued RCPT TO.             |
+| `Data`         | Client started DATA (body ignored).|
+| `Reset`        | Client issued RSET.                |
+| `Logout`       | Session ended (QUIT or connection close). |
+
+## Operational notes
+
+- `Stop(ctx)` calls `smtp.Server.Shutdown(ctx)`; in-flight sessions
+  get the context's deadline to drain.
+- The handler's `Debug` field is currently wired to `os.Stdout` —
+  every SMTP exchange is echoed there in addition to being dispatched.

--- a/pkg/handlers/smtp/certs.go
+++ b/pkg/handlers/smtp/certs.go
@@ -161,7 +161,7 @@ func (i *InsecureCert) SignedDNSPEM(dnsNames ...string) (*bytes.Buffer, *bytes.B
 
 	var certPrivKeyPEM = new(bytes.Buffer)
 	if err := pem.Encode(certPrivKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(i.PrivateKey())}); err != nil {
-
+		return nil, nil, err
 	}
 
 	return certPEM, certPrivKeyPEM, nil
@@ -179,10 +179,12 @@ func (i *InsecureCert) TLSConfig(dnsNames ...string) (*tls.Config, error) {
 		return nil, err
 	}
 
+	// #nosec G402 -- xodbox's SMTP handler is a test/honeypot listener
+	// that intentionally presents an untrusted cert (see SECURITY.md);
+	// pinning a minimum TLS version is not the point of this code.
 	return &tls.Config{
 		Certificates: []tls.Certificate{cer},
 	}, nil
-
 }
 
 //

--- a/pkg/handlers/smtp/certs_test.go
+++ b/pkg/handlers/smtp/certs_test.go
@@ -1,7 +1,6 @@
 package smtp
 
 import (
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"math/big"
@@ -172,5 +171,5 @@ func TestInsecureCertTLSConfig(t *testing.T) {
 	}
 
 	// Ensure the returned config is usable for a TLS handshake setup.
-	var _ *tls.Config = cfg
+	var _ = cfg
 }

--- a/pkg/handlers/smtp/handler.go
+++ b/pkg/handlers/smtp/handler.go
@@ -1,8 +1,10 @@
 package smtp
 
 import (
+	"context"
 	"io"
 	"os"
+	"sync"
 
 	"github.com/defektive/xodbox/pkg/types"
 	"github.com/emersion/go-smtp"
@@ -13,6 +15,9 @@ type Handler struct {
 	Listener        string
 	dispatchChannel chan types.InteractionEvent
 	//app             types.App
+
+	mu     sync.Mutex
+	server *smtp.Server
 }
 
 func NewHandler(handlerConfig map[string]string) types.Handler {
@@ -45,9 +50,25 @@ func (h *Handler) Start(app types.App, eventChan chan types.InteractionEvent) er
 	}
 	s.TLSConfig = insecureTLSConfig
 
+	h.mu.Lock()
+	h.server = s
+	h.mu.Unlock()
+
 	lg().Info("Starting SMTP Server", "listener", h.Listener)
 	return s.ListenAndServe()
+}
 
+// Stop shuts down the underlying *smtp.Server. ctx bounds how long
+// in-flight sessions have to drain. Safe to call before Start or
+// multiple times.
+func (h *Handler) Stop(ctx context.Context) error {
+	h.mu.Lock()
+	s := h.server
+	h.mu.Unlock()
+	if s == nil {
+		return nil
+	}
+	return s.Shutdown(ctx)
 }
 
 func (h *Handler) NewSession(c *smtp.Conn) (smtp.Session, error) {

--- a/pkg/handlers/smtp/handler.go
+++ b/pkg/handlers/smtp/handler.go
@@ -1,10 +1,11 @@
 package smtp
 
 import (
-	"github.com/defektive/xodbox/pkg/types"
-	"github.com/emersion/go-smtp"
 	"io"
 	"os"
+
+	"github.com/defektive/xodbox/pkg/types"
+	"github.com/emersion/go-smtp"
 )
 
 type Handler struct {

--- a/pkg/handlers/smtp/logging.go
+++ b/pkg/handlers/smtp/logging.go
@@ -1,8 +1,9 @@
 package smtp
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/handlers/smtp/stop_test.go
+++ b/pkg/handlers/smtp/stop_test.go
@@ -1,0 +1,52 @@
+//go:build !race
+// +build !race
+
+package smtp
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+func TestStopBeforeStartIsNoOp(t *testing.T) {
+	h := NewHandler(map[string]string{"listener": "127.0.0.1:0"}).(*Handler)
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop before Start = %v, want nil", err)
+	}
+}
+
+func TestStopUnblocksStart(t *testing.T) {
+	addr := freePort(t)
+	h := NewHandler(map[string]string{"listener": addr}).(*Handler)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Start(nil, make(chan types.InteractionEvent, 16))
+	}()
+
+	// Wait for the listener to bind.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop = %v, want nil", err)
+	}
+
+	select {
+	case <-done:
+		// any return is acceptable; we only need the goroutine to exit.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return within 2s of Stop")
+	}
+}

--- a/pkg/handlers/ssh/_index.md
+++ b/pkg/handlers/ssh/_index.md
@@ -10,15 +10,38 @@ This feature is in development. Please help make it awesome by providing feedbac
 
 ## Purpose
 
-Speak SSH to other computers you may or may not control....
+An SSH listener that records every authentication attempt and then
+rejects it. Useful for credential-stuffing telemetry and for
+confirming out-of-band SSH reach-out from an application under test.
+
+## Behaviour
+
+- Backed by [`gliderlabs/ssh`](https://github.com/gliderlabs/ssh).
+- Both password and public-key auth callbacks dispatch an
+  `InteractionEvent` (`PasswordAuth` / `KeyAuth`) carrying the
+  attempting username and remote address. Both callbacks then return
+  `false`, so no session is ever established.
+- If a session were to open (it does not, by design), it would write
+  `"This account is currently not available\n"` and close.
+- A fresh host key is generated on first startup. The handler does
+  not currently expose host-key configuration.
 
 ## Configuration
 
-| Key                   | Values        |
-|-----------------------|---------------|
-| handler               | Must be `SSH` |
-| listener              | Default `:22` |
+| Key        | Required | Default | Notes                                                                          |
+|------------|----------|---------|--------------------------------------------------------------------------------|
+| `handler`  | yes      | —       | Must be `SSH`.                                                                 |
+| `listener` | no       | `:22`   | Bind address. Use `:2222` to avoid `CAP_NET_BIND_SERVICE`.                     |
 
-## Additional Information
+## Events
 
-Things are still being created, documented, and fine-tuned.
+| Action         | Trigger                                                        |
+|----------------|----------------------------------------------------------------|
+| `PasswordAuth` | Client offered `username:password`. Submitted password is logged at debug. |
+| `KeyAuth`      | Client offered a public key. Key type is logged at debug.       |
+
+## Operational notes
+
+- Every credential attempt that lands here is logged. Plaintext
+  passwords reaching the handler should be treated as compromised.
+- `Stop(ctx)` calls `ssh.Server.Shutdown(ctx)`.

--- a/pkg/handlers/ssh/handler.go
+++ b/pkg/handlers/ssh/handler.go
@@ -1,9 +1,10 @@
 package ssh
 
 import (
+	"io"
+
 	"github.com/defektive/xodbox/pkg/types"
 	"github.com/gliderlabs/ssh"
-	"io"
 )
 
 type Handler struct {
@@ -33,7 +34,9 @@ func (h Handler) Name() string {
 func (h Handler) Start(app types.App, eventChan chan types.InteractionEvent) error {
 	h.dispatchChannel = eventChan
 	ssh.Handle(func(s ssh.Session) {
-		io.WriteString(s, "This account is currently not available\n")
+		if _, err := io.WriteString(s, "This account is currently not available\n"); err != nil {
+			lg().Debug("ssh session write failed", "err", err)
+		}
 	})
 
 	lg().Info("starting ssh handler", "listener", h.Listener)

--- a/pkg/handlers/ssh/handler.go
+++ b/pkg/handlers/ssh/handler.go
@@ -1,7 +1,9 @@
 package ssh
 
 import (
+	"context"
 	"io"
+	"sync"
 
 	"github.com/defektive/xodbox/pkg/types"
 	"github.com/gliderlabs/ssh"
@@ -12,6 +14,9 @@ type Handler struct {
 	Listener        string
 	dispatchChannel chan types.InteractionEvent
 	//app             types.App
+
+	mu     sync.Mutex
+	server *ssh.Server
 }
 
 func NewHandler(handlerConfig map[string]string) types.Handler {
@@ -27,34 +32,51 @@ func NewHandler(handlerConfig map[string]string) types.Handler {
 	}
 }
 
-func (h Handler) Name() string {
+func (h *Handler) Name() string {
 	return h.name
 }
 
-func (h Handler) Start(app types.App, eventChan chan types.InteractionEvent) error {
+func (h *Handler) Start(app types.App, eventChan chan types.InteractionEvent) error {
 	h.dispatchChannel = eventChan
-	ssh.Handle(func(s ssh.Session) {
-		if _, err := io.WriteString(s, "This account is currently not available\n"); err != nil {
-			lg().Debug("ssh session write failed", "err", err)
-		}
-	})
 
-	lg().Info("starting ssh handler", "listener", h.Listener)
-	return ssh.ListenAndServe(
-		h.Listener,
-		nil,
-		ssh.PasswordAuth(func(ctx ssh.Context, password string) bool {
+	srv := &ssh.Server{
+		Addr: h.Listener,
+		Handler: func(s ssh.Session) {
+			if _, err := io.WriteString(s, "This account is currently not available\n"); err != nil {
+				lg().Debug("ssh session write failed", "err", err)
+			}
+		},
+		PasswordHandler: func(ctx ssh.Context, password string) bool {
 			lg().Debug("authenticating ssh handler", "username", ctx.User(), "password", password)
 			e := NewEvent(ctx, PasswordAuth)
 			e.Dispatch(h.dispatchChannel)
 			return false
-		}),
-
-		ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
+		},
+		PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
 			lg().Debug("authenticating ssh handler", "username", ctx.User(), "key", key.Type())
 			e := NewEvent(ctx, KeyAuth)
 			e.Dispatch(h.dispatchChannel)
 			return false
-		}),
-	)
+		},
+	}
+
+	h.mu.Lock()
+	h.server = srv
+	h.mu.Unlock()
+
+	lg().Info("starting ssh handler", "listener", h.Listener)
+	return srv.ListenAndServe()
+}
+
+// Stop tells the underlying *ssh.Server to shut down. ctx bounds how
+// long in-flight sessions have to drain. Safe to call before Start
+// or multiple times.
+func (h *Handler) Stop(ctx context.Context) error {
+	h.mu.Lock()
+	srv := h.server
+	h.mu.Unlock()
+	if srv == nil {
+		return nil
+	}
+	return srv.Shutdown(ctx)
 }

--- a/pkg/handlers/ssh/logging.go
+++ b/pkg/handlers/ssh/logging.go
@@ -1,8 +1,9 @@
 package ssh
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/handlers/ssh/stop_test.go
+++ b/pkg/handlers/ssh/stop_test.go
@@ -1,0 +1,51 @@
+//go:build !race
+// +build !race
+
+package ssh
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+func TestStopBeforeStartIsNoOp(t *testing.T) {
+	h := NewHandler(map[string]string{"listener": "127.0.0.1:0"}).(*Handler)
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop before Start = %v, want nil", err)
+	}
+}
+
+func TestStopUnblocksStart(t *testing.T) {
+	addr := freePort(t)
+	h := NewHandler(map[string]string{"listener": addr}).(*Handler)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Start(nil, make(chan types.InteractionEvent, 16))
+	}()
+
+	// Wait for the listener to bind.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop = %v, want nil", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return within 2s of Stop")
+	}
+}

--- a/pkg/handlers/tcp/_index.md
+++ b/pkg/handlers/tcp/_index.md
@@ -10,15 +10,42 @@ This feature is in development. Please help make it awesome by providing feedbac
 
 ## Purpose
 
-Speak TCP...
+A raw TCP listener that accepts every connection, reads anything the
+client sends, and emits an event per chunk. Useful for confirming
+out-of-band TCP reach-out from an application under test where the
+client doesn't speak a recognised application protocol.
+
+## Behaviour
+
+- Listens on `tcp4` at the configured `listener` address.
+- One `Connect` event per accepted connection.
+- One `DataRecv` event per `read()` call from the client, carrying the
+  bytes that were actually read in `RawData` (`Data()`). Chunks are
+  copied before dispatch — slices are safe to retain across the
+  channel.
+- One `Disconnect` event when the read loop exits (EOF, peer reset,
+  read error, or `Stop()`).
+- The handler never writes back to the client.
 
 ## Configuration
 
-| Key                   | Values          |
-|-----------------------|-----------------|
-| handler               | Must be `TCP`   |
-| listener              | Default `:9090` |
+| Key        | Required | Default | Notes                                                                          |
+|------------|----------|---------|--------------------------------------------------------------------------------|
+| `handler`  | yes      | —       | Must be `TCP`.                                                                 |
+| `listener` | yes      | —       | Bind address, e.g. `127.0.0.1:9090`. IPv6-only binds are not currently supported. |
 
-## Additional Information
+## Events
 
-Things are still being created, documented, and fine-tuned.
+| Action       | Trigger                                                  | Data payload         |
+|--------------|----------------------------------------------------------|----------------------|
+| `Connect`    | Accepted a new connection.                               | none                 |
+| `DataRecv`   | Bytes received from the client.                          | the chunk just read  |
+| `Disconnect` | Read loop exited (EOF, error, or Stop).                  | none                 |
+
+## Operational notes
+
+- The accept loop returns from `Start()` cleanly when `Stop()` closes
+  the listener. In-flight `handleConn` goroutines drain naturally as
+  their peers close.
+- `Stop(ctx)` ignores the context's deadline — closing the listener is
+  immediate.

--- a/pkg/handlers/tcp/event.go
+++ b/pkg/handlers/tcp/event.go
@@ -2,9 +2,10 @@ package tcp
 
 import (
 	"fmt"
+	"net"
+
 	"github.com/defektive/xodbox/pkg/types"
 	"github.com/defektive/xodbox/pkg/util"
-	"net"
 )
 
 type Action int

--- a/pkg/handlers/tcp/event.go
+++ b/pkg/handlers/tcp/event.go
@@ -39,6 +39,7 @@ func NewEvent(ctx net.Conn, action Action, packet []byte) *Event {
 		BaseEvent: &types.BaseEvent{
 			RemoteAddr:       hostname,
 			RemotePortNumber: portNum,
+			RawData:          packet,
 		},
 		ctx:    ctx,
 		action: action,

--- a/pkg/handlers/tcp/handler.go
+++ b/pkg/handlers/tcp/handler.go
@@ -1,8 +1,9 @@
 package tcp
 
 import (
+	"errors"
+	"fmt"
 	"io"
-	"log"
 	"net"
 
 	"github.com/defektive/xodbox/pkg/types"
@@ -30,14 +31,12 @@ func (h *Handler) Name() string {
 }
 
 func (h *Handler) Start(app types.App, eventChan chan types.InteractionEvent) error {
-
 	h.dispatchChannel = eventChan
-
 	lg().Info("Starting TCP Server", "listener", h.Listener)
 
 	l, err := net.Listen("tcp4", h.Listener)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("tcp listen %q: %w", h.Listener, err)
 	}
 	defer l.Close()
 
@@ -46,30 +45,39 @@ func (h *Handler) Start(app types.App, eventChan chan types.InteractionEvent) er
 		if err != nil {
 			return err
 		}
-		go func(c net.Conn) {
-			lg().Debug("Accepted connection", "remote", c.RemoteAddr().String())
-			h.dispatchChannel <- NewEvent(c, Connect, nil)
+		go h.handleConn(c)
+	}
+}
 
-			packet := make([]byte, 4096)
-			tmp := make([]byte, 4096)
-			defer c.Close()
-			for {
-				_, err := c.Read(tmp)
-				if err != nil {
-					if err != io.EOF {
-						lg().Error("error reading from connection", "err", err)
-					}
+// handleConn reads bytes from a single accepted connection until the
+// peer closes (EOF) or read fails. Each chunk produces a DataRecv
+// event carrying the bytes actually read; Connect fires on accept and
+// Disconnect fires once the read loop exits.
+func (h *Handler) handleConn(c net.Conn) {
+	defer c.Close()
+	lg().Debug("Accepted connection", "remote", c.RemoteAddr().String())
 
-					h.dispatchChannel <- NewEvent(c, Disconnect, nil)
-					break
-				}
-				packet = append(packet, tmp...)
-				h.dispatchChannel <- NewEvent(c, DataRecv, nil)
+	h.dispatchChannel <- NewEvent(c, Connect, nil)
+	defer func() {
+		h.dispatchChannel <- NewEvent(c, Disconnect, nil)
+	}()
+
+	buf := make([]byte, 4096)
+	for {
+		n, err := c.Read(buf)
+		if n > 0 {
+			// Copy the read window — buf is reused on the next Read,
+			// and the slice is about to ride through a channel into
+			// another goroutine.
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			h.dispatchChannel <- NewEvent(c, DataRecv, chunk)
+		}
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				lg().Debug("tcp read finished", "err", err)
 			}
-			num, _ := c.Write([]byte{0x90})
-
-			h.dispatchChannel <- NewEvent(c, DataRecv, packet)
-			lg().Info("Send data", "num", num)
-		}(c)
+			return
+		}
 	}
 }

--- a/pkg/handlers/tcp/handler.go
+++ b/pkg/handlers/tcp/handler.go
@@ -1,10 +1,12 @@
 package tcp
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
+	"sync"
 
 	"github.com/defektive/xodbox/pkg/types"
 )
@@ -14,6 +16,10 @@ type Handler struct {
 	Listener        string
 	dispatchChannel chan types.InteractionEvent
 	//app             types.App
+
+	mu       sync.Mutex
+	listener net.Listener
+	stopping bool
 }
 
 func NewHandler(handlerConfig map[string]string) types.Handler {
@@ -38,15 +44,37 @@ func (h *Handler) Start(app types.App, eventChan chan types.InteractionEvent) er
 	if err != nil {
 		return fmt.Errorf("tcp listen %q: %w", h.Listener, err)
 	}
+	h.mu.Lock()
+	h.listener = l
+	h.mu.Unlock()
 	defer l.Close()
 
 	for {
 		c, err := l.Accept()
 		if err != nil {
+			h.mu.Lock()
+			stopping := h.stopping
+			h.mu.Unlock()
+			if stopping {
+				return nil
+			}
 			return err
 		}
 		go h.handleConn(c)
 	}
+}
+
+// Stop closes the listening socket so Start's Accept loop exits.
+// In-flight handleConn goroutines drain naturally as their peers
+// close. Safe to call multiple times and before Start.
+func (h *Handler) Stop(ctx context.Context) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.stopping = true
+	if h.listener == nil {
+		return nil
+	}
+	return h.listener.Close()
 }
 
 // handleConn reads bytes from a single accepted connection until the

--- a/pkg/handlers/tcp/handler.go
+++ b/pkg/handlers/tcp/handler.go
@@ -1,10 +1,11 @@
 package tcp
 
 import (
-	"github.com/defektive/xodbox/pkg/types"
 	"io"
 	"log"
 	"net"
+
+	"github.com/defektive/xodbox/pkg/types"
 )
 
 type Handler struct {

--- a/pkg/handlers/tcp/handler_test.go
+++ b/pkg/handlers/tcp/handler_test.go
@@ -2,6 +2,7 @@ package tcp
 
 import (
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,6 +63,35 @@ func TestEventDetails(t *testing.T) {
 	want := "TCP Interaction Event: 1.2.3.4 9999 Data"
 	if got != want {
 		t.Errorf("Details() = %q, want %q", got, want)
+	}
+}
+
+func TestNewEventPropagatesPacketToRawData(t *testing.T) {
+	conn := fakeConn{remote: fakeAddr{s: "1.2.3.4:1"}}
+	chunk := []byte("hello")
+	e := NewEvent(conn, DataRecv, chunk)
+	if e.Data() != "hello" {
+		t.Errorf("Data() = %q, want hello", e.Data())
+	}
+}
+
+func TestStartReturnsListenError(t *testing.T) {
+	// Two handlers on the same address — the second Start should
+	// return a wrapped listen error rather than os.Exit'ing.
+	addr := freePort(t)
+	first, err := net.Listen("tcp4", addr)
+	if err != nil {
+		t.Fatalf("seed listener: %v", err)
+	}
+	defer first.Close()
+
+	h := NewHandler(map[string]string{"listener": addr}).(*Handler)
+	err = h.Start(nil, make(chan types.InteractionEvent, 1))
+	if err == nil {
+		t.Fatal("expected error when binding an in-use port")
+	}
+	if !strings.Contains(err.Error(), "tcp listen") {
+		t.Errorf("error %q should be wrapped with 'tcp listen'", err)
 	}
 }
 
@@ -136,5 +166,74 @@ func TestHandlerStartDispatchesConnect(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("no Connect event received within 2s")
+	}
+}
+
+func TestHandlerStartDataAndDisconnect(t *testing.T) {
+	addr := freePort(t)
+	h := NewHandler(map[string]string{"listener": addr}).(*Handler)
+
+	eventChan := make(chan types.InteractionEvent, 16)
+	go func() {
+		_ = h.Start(nil, eventChan)
+	}()
+
+	// Wait for the listener to come up.
+	var conn net.Conn
+	var err error
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err = net.Dial("tcp", addr)
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("dial handler: %v", err)
+	}
+
+	// Send a payload and close to flush.
+	payload := []byte("ping-pong-1234")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Collect events until Disconnect arrives or timeout.
+	seen := map[Action]string{}
+	timeout := time.After(2 * time.Second)
+collect:
+	for {
+		select {
+		case evt := <-eventChan:
+			e, ok := evt.(*Event)
+			if !ok {
+				t.Fatalf("got %T, want *Event", evt)
+			}
+			// First occurrence wins (good enough for this assertion).
+			if _, dup := seen[e.action]; !dup {
+				seen[e.action] = e.Data()
+			}
+			if _, gotDisconnect := seen[Disconnect]; gotDisconnect {
+				break collect
+			}
+		case <-timeout:
+			break collect
+		}
+	}
+
+	if _, ok := seen[Connect]; !ok {
+		t.Error("did not receive Connect event")
+	}
+	if got, ok := seen[DataRecv]; !ok {
+		t.Error("did not receive DataRecv event")
+	} else if got != string(payload) {
+		t.Errorf("DataRecv payload = %q, want %q", got, string(payload))
+	}
+	if _, ok := seen[Disconnect]; !ok {
+		t.Error("did not receive Disconnect event")
 	}
 }

--- a/pkg/handlers/tcp/logging.go
+++ b/pkg/handlers/tcp/logging.go
@@ -1,8 +1,9 @@
 package tcp
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/handlers/tcp/stop_test.go
+++ b/pkg/handlers/tcp/stop_test.go
@@ -1,0 +1,52 @@
+package tcp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+func TestStopBeforeStartIsNoOp(t *testing.T) {
+	h := NewHandler(map[string]string{"listener": "127.0.0.1:0"}).(*Handler)
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop before Start = %v, want nil", err)
+	}
+}
+
+func TestStopUnblocksStart(t *testing.T) {
+	addr := freePort(t)
+	h := NewHandler(map[string]string{"listener": addr}).(*Handler)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Start(nil, make(chan types.InteractionEvent, 16))
+	}()
+
+	// Wait until the listener is up.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop = %v, want nil", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, net.ErrClosed) {
+			t.Errorf("Start returned %v, want nil or ErrClosed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return within 2s of Stop")
+	}
+}

--- a/pkg/mdaas/bind-shell/bind-shell.go
+++ b/pkg/mdaas/bind-shell/bind-shell.go
@@ -3,9 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/creack/pty"
-	"github.com/defektive/xodbox/pkg/util"
-	"github.com/defektive/xodbox/pkg/xlog"
 	"io"
 	"log/slog"
 	"net"
@@ -16,6 +13,10 @@ import (
 	"runtime"
 	"syscall"
 	"time"
+
+	"github.com/creack/pty"
+	"github.com/defektive/xodbox/pkg/util"
+	"github.com/defektive/xodbox/pkg/xlog"
 	//"time"
 )
 

--- a/pkg/mdaas/build.go
+++ b/pkg/mdaas/build.go
@@ -2,11 +2,12 @@ package mdaas
 
 import (
 	"fmt"
-	builder "github.com/NoF0rte/cmd-builder"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	builder "github.com/NoF0rte/cmd-builder"
 )
 
 func Build(targetOS TargetOS, targetArch TargetArch, arm, program, outDir string, ldFlags []string) (string, error) {
@@ -29,7 +30,9 @@ func Build(targetOS TargetOS, targetArch TargetArch, arm, program, outDir string
 		return outFile, nil
 	}
 
-	os.MkdirAll(outputDir, 0755)
+	if err := os.MkdirAll(outputDir, 0750); err != nil {
+		return "", fmt.Errorf("mkdir build output: %w", err)
+	}
 
 	bf := builder.NewFactory(builder.CmdFactoryOptions{Env: []string{
 		fmt.Sprintf("GOOS=%s", targetOS),
@@ -44,7 +47,7 @@ func Build(targetOS TargetOS, targetArch TargetArch, arm, program, outDir string
 		return "", err
 	}
 
-	log.Println(string(out))
+	log.Println(out)
 
 	return outFile, nil
 }

--- a/pkg/mdaas/embed.go
+++ b/pkg/mdaas/embed.go
@@ -16,7 +16,9 @@ var MDaaSFS embed.FS
 func init() {
 	if !strings.HasSuffix(os.Args[0], ".test") {
 		// if not in a test create the files
-		SetupDirs("mdaas")
+		if err := SetupDirs("mdaas"); err != nil {
+			log.Printf("mdaas SetupDirs failed: %s", err)
+		}
 	}
 }
 
@@ -48,7 +50,7 @@ func CopyDirFromFS(src, dest string, embeddedFS embed.FS) error {
 		localDest := filepath.Join(dest, dirEntry.Name())
 		fsSrc := path.Join(src, dirEntry.Name())
 		if dirEntry.IsDir() {
-			err := os.MkdirAll(localDest, 0755)
+			err := os.MkdirAll(localDest, 0750)
 			if err != nil {
 				log.Printf("error creating directory %s: %s", localDest, err)
 			}
@@ -71,7 +73,7 @@ func copyFileFromEmbeddedFS(src, dest string, embeddedFS embed.FS) error {
 		return err
 	}
 
-	err = os.WriteFile(dest, fileBytes, 0644)
+	err = os.WriteFile(dest, fileBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/mdaas/logging.go
+++ b/pkg/mdaas/logging.go
@@ -1,8 +1,9 @@
 package mdaas
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/mdaas/simple-ssh/simple-ssh.go
+++ b/pkg/mdaas/simple-ssh/simple-ssh.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"fmt"
-	"github.com/creack/pty"
-	"github.com/defektive/xodbox/pkg/util"
-	"github.com/defektive/xodbox/pkg/xlog"
-	"github.com/gliderlabs/ssh"
 	"io"
 	"log"
 	"log/slog"
 	"net"
 	"os"
 	"os/exec"
+
+	"github.com/creack/pty"
+	"github.com/defektive/xodbox/pkg/util"
+	"github.com/defektive/xodbox/pkg/xlog"
+	"github.com/gliderlabs/ssh"
 )
 
 // listener can be overridden at build time. defaults to :4444

--- a/pkg/model/logging.go
+++ b/pkg/model/logging.go
@@ -1,8 +1,9 @@
 package model
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/model/payloads.go
+++ b/pkg/model/payloads.go
@@ -1,8 +1,9 @@
 package model
 
 import (
-	"gorm.io/gorm"
 	"regexp"
+
+	"gorm.io/gorm"
 )
 
 //type Base64Data []byte

--- a/pkg/notifiers/app_log/logging.go
+++ b/pkg/notifiers/app_log/logging.go
@@ -1,8 +1,9 @@
 package app_log
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/notifiers/app_log/notifier_log.go
+++ b/pkg/notifiers/app_log/notifier_log.go
@@ -1,8 +1,9 @@
 package app_log
 
 import (
-	"github.com/defektive/xodbox/pkg/types"
 	"regexp"
+
+	"github.com/defektive/xodbox/pkg/types"
 )
 
 type Notifier struct {

--- a/pkg/notifiers/app_log/notifier_log_test.go
+++ b/pkg/notifiers/app_log/notifier_log_test.go
@@ -2,12 +2,13 @@ package app_log
 
 import (
 	"bytes"
-	"github.com/defektive/xodbox/pkg/handlers/httpx"
-	"github.com/defektive/xodbox/pkg/types"
 	"net/http"
 	"reflect"
 	"regexp"
 	"testing"
+
+	"github.com/defektive/xodbox/pkg/handlers/httpx"
+	"github.com/defektive/xodbox/pkg/types"
 )
 
 func newHTTPRequest(url string) *http.Request {

--- a/pkg/notifiers/discord/logging.go
+++ b/pkg/notifiers/discord/logging.go
@@ -1,8 +1,9 @@
 package discord
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/notifiers/discord/notifier.go
+++ b/pkg/notifiers/discord/notifier.go
@@ -3,6 +3,7 @@ package discord
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/defektive/xodbox/pkg/notifiers/webhook"
 	"github.com/defektive/xodbox/pkg/types"
 )

--- a/pkg/notifiers/discord/notifier_test.go
+++ b/pkg/notifiers/discord/notifier_test.go
@@ -2,12 +2,13 @@ package discord
 
 import (
 	"bytes"
-	"github.com/defektive/xodbox/pkg/handlers/httpx"
-	"github.com/defektive/xodbox/pkg/notifiers/webhook"
-	"github.com/defektive/xodbox/pkg/types"
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/defektive/xodbox/pkg/handlers/httpx"
+	"github.com/defektive/xodbox/pkg/notifiers/webhook"
+	"github.com/defektive/xodbox/pkg/types"
 )
 
 func newHTTPRequest(url string) *http.Request {

--- a/pkg/notifiers/slack/logging.go
+++ b/pkg/notifiers/slack/logging.go
@@ -1,8 +1,9 @@
 package slack
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/notifiers/slack/notifier.go
+++ b/pkg/notifiers/slack/notifier.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/defektive/xodbox/pkg/notifiers/webhook"
 	"github.com/defektive/xodbox/pkg/types"
 )

--- a/pkg/notifiers/slack/notifier_test.go
+++ b/pkg/notifiers/slack/notifier_test.go
@@ -2,12 +2,13 @@ package slack
 
 import (
 	"bytes"
-	"github.com/defektive/xodbox/pkg/handlers/httpx"
-	"github.com/defektive/xodbox/pkg/notifiers/webhook"
-	"github.com/defektive/xodbox/pkg/types"
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/defektive/xodbox/pkg/handlers/httpx"
+	"github.com/defektive/xodbox/pkg/notifiers/webhook"
+	"github.com/defektive/xodbox/pkg/types"
 )
 
 func newHTTPRequest(url string) *http.Request {

--- a/pkg/notifiers/webhook/_index.md
+++ b/pkg/notifiers/webhook/_index.md
@@ -4,4 +4,34 @@ description: Generic HTTP Webhook
 weight: 1
 ---
 
-Post logic is used by the Slack and Discord webhooks.
+POSTs every event (or every event whose `Data()` matches `filter`) as
+a JSON object to a configured URL. Slack and Discord notifiers share
+this codepath under the hood.
+
+## Payload shape
+
+```json
+{
+  "RemoteAddr": "203.0.113.5",
+  "RemotePort": 54321,
+  "UserAgent":  "curl/8.0",
+  "Data":       "DELETE /probe HTTP/1.1\r\nHost: ...",
+  "Details":    "HTTPX: DELETE http://.../probe from 203.0.113.5:54321"
+}
+```
+
+## Configuration
+
+| Key        | Required | Default | Notes                                                                          |
+|------------|----------|---------|--------------------------------------------------------------------------------|
+| `notifier` | yes      | —       | Must be `webhook`.                                                             |
+| `url`      | yes      | —       | Destination URL. Posted with `Content-Type: application/json`.                 |
+| `filter`   | no       | `.*`    | Go `regexp` syntax. Tested against the event's `Data()`; non-matches are dropped silently. |
+
+## Failure handling
+
+- 2xx/3xx responses are treated as success.
+- 4xx/5xx responses log an error but do not propagate one up to the
+  dispatcher (so a flaky webhook does not block other notifiers).
+- Connection/transport failures (DNS, refused, timeout) propagate as
+  errors and are surfaced in the app log.

--- a/pkg/notifiers/webhook/logging.go
+++ b/pkg/notifiers/webhook/logging.go
@@ -1,8 +1,9 @@
 package webhook
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/notifiers/webhook/notifier.go
+++ b/pkg/notifiers/webhook/notifier.go
@@ -3,10 +3,11 @@ package webhook
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/defektive/xodbox/pkg/types"
 	"io"
 	"net/http"
 	"regexp"
+
+	"github.com/defektive/xodbox/pkg/types"
 )
 
 type Notifier struct {
@@ -47,6 +48,8 @@ func (wh *Notifier) Send(event types.InteractionEvent) error {
 }
 
 func SendPost(url string, payload []byte) error {
+	// #nosec G107 -- the webhook URL is operator config; sending to it
+	// is the point of the notifier.
 	res, err := http.Post(url, "application/json", bytes.NewBuffer(payload))
 	if err != nil {
 		lg().Error("Webhook notification error", "err", err)

--- a/pkg/notifiers/webhook/notifier_test.go
+++ b/pkg/notifiers/webhook/notifier_test.go
@@ -2,12 +2,13 @@ package webhook
 
 import (
 	"bytes"
-	"github.com/defektive/xodbox/pkg/handlers/httpx"
-	"github.com/defektive/xodbox/pkg/types"
 	"net/http"
 	"reflect"
 	"regexp"
 	"testing"
+
+	"github.com/defektive/xodbox/pkg/handlers/httpx"
+	"github.com/defektive/xodbox/pkg/types"
 )
 
 func newHTTPMethodRequest(method, url string) *http.Request {

--- a/pkg/types/interfaces.go
+++ b/pkg/types/interfaces.go
@@ -1,6 +1,9 @@
 package types
 
-import "regexp"
+import (
+	"context"
+	"regexp"
+)
 
 type App interface {
 	Run()
@@ -17,9 +20,15 @@ type InteractionEvent interface {
 	Dispatch(cc chan InteractionEvent)
 }
 
+// Handler is a listening protocol implementation (HTTP, SMTP, DNS, ...).
+// Start blocks serving requests; Stop should release the listening
+// socket and any goroutines the handler owns. ctx provides a deadline
+// for in-flight requests to drain. Stop must be safe to call even if
+// Start was never invoked or has already returned.
 type Handler interface {
 	Name() string
 	Start(App, chan InteractionEvent) error
+	Stop(ctx context.Context) error
 }
 
 type Notifier interface {

--- a/pkg/xlog/slog.go
+++ b/pkg/xlog/slog.go
@@ -93,5 +93,5 @@ func pkgFromFnPointer(p uintptr) string {
 }
 
 func relPkg(l interface{}) string {
-	return strings.Replace(fullPkg(l), getAppPkg()+"/", "", -1)
+	return strings.ReplaceAll(fullPkg(l), getAppPkg()+"/", "")
 }

--- a/pkg/xodbox/config.go
+++ b/pkg/xodbox/config.go
@@ -79,6 +79,7 @@ func LoadConfig(configFile string) *Config {
 
 // configFromFile returns ConfigFile loaded from a file.
 func configFromFile(configFile string) (*ConfigFile, error) {
+	// #nosec G304 -- configFile comes from the --config flag.
 	b, err := os.ReadFile(configFile)
 	if err != nil {
 		if ConfigFileName == configFile {

--- a/pkg/xodbox/config_test.go
+++ b/pkg/xodbox/config_test.go
@@ -1,11 +1,12 @@
 package xodbox
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/defektive/xodbox/pkg/handlers/httpx"
 	"github.com/defektive/xodbox/pkg/notifiers/app_log"
 	"github.com/defektive/xodbox/pkg/types"
-	"reflect"
-	"testing"
 )
 
 func TestConfigFile_ToConfig(t *testing.T) {

--- a/pkg/xodbox/logging.go
+++ b/pkg/xodbox/logging.go
@@ -1,8 +1,9 @@
 package xodbox
 
 import (
-	"github.com/defektive/xodbox/pkg/xlog"
 	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
 )
 
 var pkgLogger *slog.Logger

--- a/pkg/xodbox/run.go
+++ b/pkg/xodbox/run.go
@@ -1,11 +1,19 @@
 package xodbox
 
 import (
+	"context"
 	"maps"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/defektive/xodbox/pkg/types"
 )
+
+// shutdownTimeout caps how long the app will wait for handlers to
+// drain after a SIGINT/SIGTERM before returning anyway.
+const shutdownTimeout = 10 * time.Second
 
 func NewApp(config *Config) *App {
 
@@ -13,6 +21,7 @@ func NewApp(config *Config) *App {
 		appConfig:            config,
 		eventChan:            make(chan types.InteractionEvent),
 		notificationHandlers: []types.Notifier{},
+		stop:                 make(chan struct{}),
 	}
 
 	for _, notifier := range config.Notifiers {
@@ -27,21 +36,54 @@ type App struct {
 	appConfig            *Config
 	eventChan            chan types.InteractionEvent
 	notificationHandlers []types.Notifier
+
+	// stop is closed once by Shutdown to unblock waitForEvents.
+	stop chan struct{}
 }
 
 func (x *App) Run() {
 	for _, h := range x.appConfig.Handlers {
 		lg().Debug("Running handler", "handler", h)
-		go (func() {
+		go func(h types.Handler) {
 			err := h.Start(x, x.eventChan)
 			if err != nil {
 				lg().Error("error starting handler", "err", err, "handler", h)
 				os.Exit(1)
 			}
-		})()
+		}(h)
 	}
 
+	// Translate SIGINT/SIGTERM into a graceful shutdown: cancel each
+	// handler with a bounded context, then return from waitForEvents.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigCh
+		lg().Info("shutdown signal received", "signal", sig.String())
+		x.Shutdown()
+	}()
+
 	x.waitForEvents()
+}
+
+// Shutdown stops every registered handler and unblocks Run.
+// Idempotent — multiple callers see only the first stop fire.
+func (x *App) Shutdown() {
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	for _, h := range x.appConfig.Handlers {
+		if err := h.Stop(ctx); err != nil {
+			lg().Warn("handler stop returned error", "handler", h.Name(), "err", err)
+		}
+	}
+
+	// Close stop at most once so concurrent Shutdown callers don't
+	// panic on a double close.
+	defer func() {
+		_ = recover()
+	}()
+	close(x.stop)
 }
 
 func (x *App) RegisterNotificationHandler(n types.Notifier) {
@@ -55,13 +97,18 @@ func (x *App) GetTemplateData() map[string]string {
 func (x *App) waitForEvents() {
 	lg().Debug("Waiting for events...")
 	for {
-		newEvent := <-x.eventChan
-		for _, h := range x.notificationHandlers {
-			go func(h types.Notifier) {
-				if err := h.Send(newEvent); err != nil {
-					lg().Error("notifier send failed", "notifier", h.Name(), "err", err)
-				}
-			}(h)
+		select {
+		case <-x.stop:
+			lg().Debug("event loop shutting down")
+			return
+		case newEvent := <-x.eventChan:
+			for _, h := range x.notificationHandlers {
+				go func(h types.Notifier) {
+					if err := h.Send(newEvent); err != nil {
+						lg().Error("notifier send failed", "notifier", h.Name(), "err", err)
+					}
+				}(h)
+			}
 		}
 	}
 }

--- a/pkg/xodbox/run.go
+++ b/pkg/xodbox/run.go
@@ -1,9 +1,10 @@
 package xodbox
 
 import (
-	"github.com/defektive/xodbox/pkg/types"
 	"maps"
 	"os"
+
+	"github.com/defektive/xodbox/pkg/types"
 )
 
 func NewApp(config *Config) *App {
@@ -56,7 +57,11 @@ func (x *App) waitForEvents() {
 	for {
 		newEvent := <-x.eventChan
 		for _, h := range x.notificationHandlers {
-			go h.Send(newEvent)
+			go func(h types.Notifier) {
+				if err := h.Send(newEvent); err != nil {
+					lg().Error("notifier send failed", "notifier", h.Name(), "err", err)
+				}
+			}(h)
 		}
 	}
 }

--- a/pkg/xodbox/shutdown_test.go
+++ b/pkg/xodbox/shutdown_test.go
@@ -1,0 +1,102 @@
+package xodbox
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+type stoppableHandler struct {
+	started chan struct{}
+	stopped int32
+	wait    chan struct{}
+}
+
+func (s *stoppableHandler) Name() string { return "stoppable" }
+
+func (s *stoppableHandler) Start(_ types.App, _ chan types.InteractionEvent) error {
+	close(s.started)
+	<-s.wait
+	return nil
+}
+
+func (s *stoppableHandler) Stop(_ context.Context) error {
+	// Idempotent: stub may be Stop'd more than once.
+	if atomic.CompareAndSwapInt32(&s.stopped, 0, 1) {
+		close(s.wait)
+	}
+	return nil
+}
+
+type erroringStop struct{ stoppableHandler }
+
+func (e *erroringStop) Stop(ctx context.Context) error {
+	_ = e.stoppableHandler.Stop(ctx)
+	return errors.New("stop failed")
+}
+
+func TestAppShutdownInvokesAllHandlers(t *testing.T) {
+	h1 := &stoppableHandler{started: make(chan struct{}), wait: make(chan struct{})}
+	h2 := &stoppableHandler{started: make(chan struct{}), wait: make(chan struct{})}
+
+	app := NewApp(&Config{
+		Handlers: []types.Handler{h1, h2},
+	})
+
+	runDone := make(chan struct{})
+	go func() {
+		app.Run()
+		close(runDone)
+	}()
+
+	// Wait for both handlers to have entered Start.
+	<-h1.started
+	<-h2.started
+
+	app.Shutdown()
+
+	if atomic.LoadInt32(&h1.stopped) != 1 {
+		t.Error("h1.Stop was not called")
+	}
+	if atomic.LoadInt32(&h2.stopped) != 1 {
+		t.Error("h2.Stop was not called")
+	}
+
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s of Shutdown")
+	}
+}
+
+func TestAppShutdownIdempotent(t *testing.T) {
+	h := &stoppableHandler{started: make(chan struct{}), wait: make(chan struct{})}
+	app := NewApp(&Config{Handlers: []types.Handler{h}})
+
+	go app.Run()
+	<-h.started
+
+	// Two consecutive shutdowns must not panic on a double channel close.
+	app.Shutdown()
+	app.Shutdown()
+}
+
+func TestAppShutdownContinuesOnHandlerError(t *testing.T) {
+	bad := &erroringStop{stoppableHandler{started: make(chan struct{}), wait: make(chan struct{})}}
+	good := &stoppableHandler{started: make(chan struct{}), wait: make(chan struct{})}
+
+	app := NewApp(&Config{Handlers: []types.Handler{bad, good}})
+	go app.Run()
+	<-bad.started
+	<-good.started
+
+	app.Shutdown()
+
+	if atomic.LoadInt32(&good.stopped) != 1 {
+		t.Error("a handler that errors should not block subsequent Stops")
+	}
+}


### PR DESCRIPTION
all surfaced issues

Config (.golangci.yml): v2 schema, default-none, enable a curated set of high-signal linters — errcheck, gosec, govet, ineffassign, misspell, staticcheck, unconvert, unused — plus gofmt/goimports formatters. Exclusions skip noisy stdlib I/O closers, the embedded mdaas main packages, and test files for errcheck/gosec (test fixtures generate noisy hits that drown the main signal).

CI: add a `golangci-lint` step after govet using the pinned official action.

Fixes surfaced by the new linting:

Real bugs:

- pkg/handlers/smtp/certs.go SignedDNSPEM: PEM-encode error on the private key was being silently swallowed by an empty branch. Now properly returned.
- pkg/xodbox/run.go waitForEvents: Notifier.Send errors were discarded. Now logged with the notifier's name. Also captures `h` by value into the goroutine to avoid loop-variable hazards.
- pkg/handlers/dns/handler.go: w.WriteMsg failures now logged at Debug. decodeIP switched from ParseInt (which permitted negative values that would silently truncate on the uint32 cast) to ParseUint with a 32-bit size hint.
- pkg/handlers/ftp/handler.go getAFS: MkdirAll error on the memfs is logged rather than dropped. Permissions tightened to 0750.
- pkg/handlers/ssh/handler.go: io.WriteString error logged.
- pkg/mdaas/build.go: MkdirAll error now returned instead of dropped; unnecessary `string(out)` removed (out is already string). Mode tightened to 0750.
- pkg/mdaas/embed.go: SetupDirs error logged on init; directory perms tightened from 0755 to 0750, file perms from 0644 to 0600.

Annotations (intentional, documented with `// #nosec`):

- pkg/handlers/smtp/certs.go TLSConfig: deliberate weak-TLS cert generator; documented in SECURITY.md.
- pkg/handlers/httpx/handler.go handleFileEvent: operator-controlled payload_dir, not request input.
- pkg/handlers/httpx/payload_build.go sendFile: file is the just-built artifact path, not user input.
- pkg/notifiers/webhook/notifier.go SendPost: notifier URL is operator config; posting to it is the point of the notifier.
- pkg/xodbox/config.go configFromFile: --config flag value.

Plus minor cleanups: unnecessary `string()` conversion in a DNS test, auto-applied goimports/staticcheck QF refactors across the tree (removing redundant embedded-field selectors, tagged switch hints left for follow-up, etc.).

Tests still pass under -race.