### PR TITLE
resolve the two remaining TODOs in httpx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ certs/
 *.db
 *.db-journal
 dist/
+bin/
+coverage.out
 
 xodbox_static
 /xodbox

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,8 +55,11 @@ linters:
           - errcheck
           - gosec
       # The embedded mdaas main programs live under build tags / are
-      # not part of normal xodbox builds.
-      - path: pkg/mdaas/(bind-shell|simple-ssh)/
+      # not part of normal xodbox builds. Both the embed source
+      # (pkg/mdaas/) and the runtime extraction target (./mdaas/,
+      # created by embed.go's init at test/server startup) are
+      # excluded from quality linting.
+      - path: (^|/)mdaas/(bind-shell|simple-ssh)/
         linters:
           - errcheck
           - gosec

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+# xodbox developer workflow.
+#
+#   make help           print every target
+#   make test           run the full test suite
+#   make race           run the test suite with the race detector
+#   make cover          run tests with a coverage profile and print the summary
+#   make lint           run golangci-lint
+#   make fmt            run gofmt -s -w over the repo
+#   make build          build the xodbox binary into ./bin/
+#   make run            build then start the server with the embedded config
+#   make tidy           run go mod tidy and verify no go.mod / go.sum changes
+#   make release-dry    run goreleaser in snapshot mode (requires syft + cosign)
+#   make clean          remove the local build / coverage artifacts
+
+GO              ?= go
+GOLANGCI_LINT   ?= golangci-lint
+GORELEASER      ?= goreleaser
+
+BIN_DIR         := bin
+COVERAGE_FILE   := coverage.out
+PKG             := ./...
+
+VERSION         := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT          := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+LDFLAGS         := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT)
+
+.DEFAULT_GOAL := help
+
+.PHONY: help test race cover lint fmt build run tidy release-dry clean
+
+help: ## print every target
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+test: ## run the full test suite
+	$(GO) test -timeout 120s $(PKG)
+
+race: ## run the test suite with the race detector
+	$(GO) test -race -timeout 180s $(PKG)
+
+cover: ## run tests with a coverage profile and print the summary
+	$(GO) test -race -timeout 180s -coverprofile=$(COVERAGE_FILE) $(PKG)
+	$(GO) tool cover -func=$(COVERAGE_FILE) | tail -1
+
+lint: ## run golangci-lint
+	$(GOLANGCI_LINT) run $(PKG)
+
+fmt: ## run gofmt -s -w over the repo
+	gofmt -s -w .
+
+build: ## build the xodbox binary into ./bin/
+	mkdir -p $(BIN_DIR)
+	CGO_ENABLED=0 $(GO) build -trimpath -ldflags '$(LDFLAGS)' -o $(BIN_DIR)/xodbox ./
+
+run: build ## build then start the server with the embedded config
+	$(BIN_DIR)/xodbox serve
+
+tidy: ## run go mod tidy and verify no go.mod / go.sum changes
+	$(GO) mod tidy
+	@if ! git diff --quiet -- go.mod go.sum; then \
+		echo "go.mod / go.sum changed after 'go mod tidy'; commit the diff."; \
+		git --no-pager diff -- go.mod go.sum; \
+		exit 1; \
+	fi
+
+release-dry: ## run goreleaser in snapshot mode (requires syft + cosign)
+	$(GORELEASER) release --snapshot --clean --skip=publish,sign,sbom
+
+clean: ## remove the local build / coverage artifacts
+	rm -rf $(BIN_DIR) $(COVERAGE_FILE) dist

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gin-contrib/sse v1.1.1 // indirect
 	github.com/glebarez/go-sqlite v1.22.0 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GM
 github.com/glebarez/sqlite v1.11.0/go.mod h1:h8/o8j5wiAsqSPoWELDUdJXhjAhsVliSn7bWZjOhrgQ=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=

--- a/pkg/handlers/httpx/_index.md
+++ b/pkg/handlers/httpx/_index.md
@@ -92,11 +92,12 @@ And would not match:
 
 ## Operational notes
 
-- `Stop(ctx)` shuts down the HTTP server with `http.Server.Shutdown(ctx)`
-  and cancels the payload-watcher goroutine if one was started. The
-  HTTPS path is served by certmagic and is **not** graceful-shutdown
-  aware today — `Stop()` returns nil but the certmagic listeners stay
-  up until the process exits. Tracked as follow-up.
+- `Stop(ctx)` shuts down whichever server pair Start booted: in HTTP
+  mode, the single `*http.Server`; in HTTPS mode, both the ACME
+  HTTP-01 challenge listener on :80 and the TLS listener on :443. The
+  payload-directory watcher goroutine (if `payload_dir` was set) is
+  also cancelled. ctx bounds how long in-flight requests have to
+  drain.
 - Sensitive operator keys (`api_token`, `dns_provider_api_key`) end up
   in the xodbox config file. Restrict that file's permissions to `0600`
   and the running user.

--- a/pkg/handlers/httpx/handler.go
+++ b/pkg/handlers/httpx/handler.go
@@ -3,6 +3,7 @@ package httpx
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
@@ -49,9 +50,11 @@ type Handler struct {
 	app             types.App
 	mux             *http.ServeMux
 
-	mu          sync.Mutex
-	httpServer  *http.Server
-	watchCancel context.CancelFunc
+	mu                  sync.Mutex
+	httpServer          *http.Server
+	httpChallengeServer *http.Server // ACME HTTP-01 listener on :80 (HTTPS path only)
+	httpsServer         *http.Server // TLS-terminated listener on :443
+	watchCancel         context.CancelFunc
 }
 
 func NewHandler(handlerConfig map[string]string) types.Handler {
@@ -220,8 +223,84 @@ func (h *Handler) serveHTTPS() error {
 		}
 	}
 
-	// eventually we'll figure out what config options we want
-	return HTTPS(h.TLSNames, h.serverMux(), false)
+	return h.serveTLS(h.TLSNames, h.serverMux(), false)
+}
+
+// serveTLS provisions certificates for domainNames via certmagic,
+// binds both the ACME HTTP-01 challenge listener (port 80) and the
+// TLS listener (port 443), and serves until Stop is called. The
+// resulting *http.Server instances are recorded on the Handler so
+// Stop can shut them down gracefully. Blocks on the TLS Serve.
+func (h *Handler) serveTLS(domainNames []string, mux http.Handler, forwardHTTP bool) error {
+	ctx := context.Background()
+
+	if mux == nil {
+		mux = http.DefaultServeMux
+	}
+
+	cfg := certmagic.NewDefault()
+	if err := cfg.ManageSync(ctx, domainNames); err != nil {
+		return err
+	}
+
+	hln, err := net.Listen("tcp", fmt.Sprintf(":%d", certmagic.HTTPPort))
+	if err != nil {
+		return fmt.Errorf("acme challenge listener: %w", err)
+	}
+
+	tlsConfig := cfg.TLSConfig()
+	tlsConfig.NextProtos = append([]string{"h2", "http/1.1"}, tlsConfig.NextProtos...)
+
+	hsln, err := tls.Listen("tcp", fmt.Sprintf(":%d", certmagic.HTTPSPort), tlsConfig)
+	if err != nil {
+		hln.Close()
+		return fmt.Errorf("tls listener: %w", err)
+	}
+
+	httpServer := &http.Server{
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       5 * time.Second,
+		WriteTimeout:      5 * time.Second,
+		IdleTimeout:       5 * time.Second,
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+	}
+
+	if len(cfg.Issuers) > 0 {
+		if am, ok := cfg.Issuers[0].(*certmagic.ACMEIssuer); ok {
+			if forwardHTTP {
+				httpServer.Handler = am.HTTPChallengeHandler(http.HandlerFunc(httpRedirectHandler))
+			} else {
+				httpServer.Handler = am.HTTPChallengeHandler(mux)
+			}
+		}
+	}
+
+	httpsServer := &http.Server{
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      2 * time.Minute,
+		IdleTimeout:       5 * time.Minute,
+		Handler:           mux,
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+	}
+
+	h.mu.Lock()
+	h.httpChallengeServer = httpServer
+	h.httpsServer = httpsServer
+	h.mu.Unlock()
+
+	log.Printf("%v Serving HTTP->HTTPS on %s and %s", domainNames, hln.Addr(), hsln.Addr())
+
+	go func() {
+		if err := httpServer.Serve(hln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			lg().Error("acme challenge server failed", "err", err)
+		}
+	}()
+
+	if err := httpsServer.Serve(hsln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
 }
 
 func (h *Handler) Start(app types.App, eventChan chan types.InteractionEvent) error {
@@ -238,13 +317,16 @@ func (h *Handler) Start(app types.App, eventChan chan types.InteractionEvent) er
 	return h.serveHTTP()
 }
 
-// Stop shuts down the HTTP server (HTTPS is not currently
-// shutdown-aware: certmagic owns the listeners) and cancels the
+// Stop shuts down whichever server(s) Start booted (plain HTTP, or
+// the HTTPS pair of ACME-challenge + TLS server) and cancels the
 // payload-directory watcher goroutine if one was started. Safe to
-// call before Start or multiple times.
+// call before Start or multiple times. Returns the first non-nil
+// error encountered, but always attempts every shutdown.
 func (h *Handler) Stop(ctx context.Context) error {
 	h.mu.Lock()
 	srv := h.httpServer
+	challenge := h.httpChallengeServer
+	tlsSrv := h.httpsServer
 	cancel := h.watchCancel
 	h.watchCancel = nil
 	h.mu.Unlock()
@@ -252,10 +334,20 @@ func (h *Handler) Stop(ctx context.Context) error {
 	if cancel != nil {
 		cancel()
 	}
-	if srv == nil {
-		return nil
+
+	var firstErr error
+	shutdown := func(s *http.Server) {
+		if s == nil {
+			return
+		}
+		if err := s.Shutdown(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
-	return srv.Shutdown(ctx)
+	shutdown(srv)
+	shutdown(challenge)
+	shutdown(tlsSrv)
+	return firstErr
 }
 
 func (h *Handler) noIndex(next http.Handler) http.Handler {
@@ -418,103 +510,9 @@ func (d *debouncer) add(f func()) {
 	d.timer = time.AfterFunc(d.after, f)
 }
 
-// From Certmagic, since I am also opinionated... :D
-// Variables for conveniently serving HTTPS.
-var (
-	httpLn, httpsLn net.Listener
-	lnMu            sync.Mutex
-	httpWg          sync.WaitGroup
-)
-
-func HTTPS(domainNames []string, mux http.Handler, forwardHTTP bool) error {
-	ctx := context.Background()
-
-	if mux == nil {
-		mux = http.DefaultServeMux
-	}
-
-	cfg := certmagic.NewDefault()
-
-	err := cfg.ManageSync(ctx, domainNames)
-	if err != nil {
-		return err
-	}
-
-	httpWg.Add(1)
-	defer httpWg.Done()
-
-	// if we haven't made listeners yet, do so now,
-	// and clean them up when all servers are done
-	lnMu.Lock()
-	if httpLn == nil && httpsLn == nil {
-		httpLn, err = net.Listen("tcp", fmt.Sprintf(":%d", certmagic.HTTPPort))
-		if err != nil {
-			lnMu.Unlock()
-			return err
-		}
-
-		tlsConfig := cfg.TLSConfig()
-		tlsConfig.NextProtos = append([]string{"h2", "http/1.1"}, tlsConfig.NextProtos...)
-
-		httpsLn, err = tls.Listen("tcp", fmt.Sprintf(":%d", certmagic.HTTPSPort), tlsConfig)
-		if err != nil {
-			httpLn.Close()
-			httpLn = nil
-			lnMu.Unlock()
-			return err
-		}
-
-		go func() {
-			httpWg.Wait()
-			lnMu.Lock()
-			httpLn.Close()
-			httpsLn.Close()
-			lnMu.Unlock()
-		}()
-	}
-	hln, hsln := httpLn, httpsLn
-	//hsln := httpsLn
-	lnMu.Unlock()
-
-	// create HTTP/S servers that are configured
-	// with sane default timeouts and appropriate
-	// handlers (the HTTP server solves the HTTP
-	// challenge and issues redirects to HTTPS,
-	// while the HTTPS server simply serves the
-	// user's handler)
-	httpServer := &http.Server{
-		ReadHeaderTimeout: 5 * time.Second,
-		ReadTimeout:       5 * time.Second,
-		WriteTimeout:      5 * time.Second,
-		IdleTimeout:       5 * time.Second,
-		BaseContext:       func(listener net.Listener) context.Context { return ctx },
-	}
-
-	if len(cfg.Issuers) > 0 {
-		if am, ok := cfg.Issuers[0].(*certmagic.ACMEIssuer); ok {
-			if forwardHTTP {
-				httpServer.Handler = am.HTTPChallengeHandler(http.HandlerFunc(httpRedirectHandler))
-			} else {
-				httpServer.Handler = am.HTTPChallengeHandler(mux)
-
-			}
-		}
-	}
-
-	httpsServer := &http.Server{
-		ReadHeaderTimeout: 10 * time.Second,
-		ReadTimeout:       30 * time.Second,
-		WriteTimeout:      2 * time.Minute,
-		IdleTimeout:       5 * time.Minute,
-		Handler:           mux,
-		BaseContext:       func(listener net.Listener) context.Context { return ctx },
-	}
-
-	log.Printf("%v Serving HTTP->HTTPS on %s and %s", domainNames, hln.Addr(), hsln.Addr())
-
-	go httpServer.Serve(hln)
-	return httpsServer.Serve(hsln)
-}
+// (Previously defined a package-level HTTPS() helper plus a singleton
+// set of certmagic listeners. Replaced by (*Handler).serveTLS so the
+// Handler owns the server instances and Stop can shut them down.)
 
 func httpRedirectHandler(w http.ResponseWriter, r *http.Request) {
 	toURL := "https://"

--- a/pkg/handlers/httpx/handler.go
+++ b/pkg/handlers/httpx/handler.go
@@ -56,13 +56,6 @@ type Handler struct {
 
 func NewHandler(handlerConfig map[string]string) types.Handler {
 
-	// I believe interface implementors should own seeding their data models
-	// TODO: add method to interface to facilitate Seeding data.
-	// data seeding cannot happen in an `init` function since we need input from the user
-	// about what db to use
-	// Seed data models
-	Seed(model.DB())
-
 	staticDir := handlerConfig["static_dir"]
 	payloadDir := handlerConfig["payload_dir"]
 	listener := handlerConfig["listener"]
@@ -119,6 +112,14 @@ func NewHandler(handlerConfig map[string]string) types.Handler {
 
 func (h *Handler) Name() string {
 	return h.name
+}
+
+// Seed populates the bundled HTTPX payload templates into the database.
+// Implements types.Seeder; called once by App.Run before Start. The
+// underlying Seed function is idempotent.
+func (h *Handler) Seed() error {
+	Seed(model.DB())
+	return nil
 }
 func (h *Handler) serverMux() *http.ServeMux {
 	if h.mux == nil {

--- a/pkg/handlers/httpx/payload.go
+++ b/pkg/handlers/httpx/payload.go
@@ -192,18 +192,9 @@ func (h *Payload) Process(w http.ResponseWriter, e *Event, handler *Handler) {
 		w.WriteHeader(responseStatus)
 	}
 
-	// TODO: If this is still a ghetto if statement.... we should make it more elegant if there are more than 3 blocks
-	switch h.InternalFunction {
-	case InternalFnInspect:
-		// ghetto hack cause I am lazy
-		if err := Inspect(w, e); err != nil {
-			lg().Error("Error executing build textTemplate", "payload", h.Name, "err", err)
-		}
-		return
-	case InternalFnBuild:
-		lg().Debug("building payload", "payload", h.Name, "payload", h)
-		if err := Build(w, e, handler); err != nil {
-			lg().Error("Error executing build textTemplate", "payload", h.Name, "err", err)
+	if fn, ok := internalFunctions[h.InternalFunction]; ok {
+		if err := fn(w, e, handler); err != nil {
+			lg().Error("internal function failed", "payload", h.Name, "fn", h.InternalFunction, "err", err)
 		}
 		return
 	}
@@ -213,6 +204,21 @@ func (h *Payload) Process(w http.ResponseWriter, e *Event, handler *Handler) {
 		lg().Error("Error executing body textTemplate", "payload", h.Name, "err", err)
 		fmt.Fprint(w, "that was unexpected")
 	}
+}
+
+// internalFn is the shape used by `internal_function` payload entries.
+// Each entry receives the response writer, the inbound event, and the
+// owning handler (for runtime config like MDaaS settings).
+type internalFn func(w http.ResponseWriter, e *Event, handler *Handler) error
+
+// internalFunctions is the dispatch table for the `internal_function`
+// payload key. Add a new entry here to expose a new internal function
+// to payload authors; the constants live in payload_db_seed.go.
+var internalFunctions = map[string]internalFn{
+	InternalFnInspect: func(w http.ResponseWriter, e *Event, _ *Handler) error {
+		return Inspect(w, e)
+	},
+	InternalFnBuild: Build,
 }
 
 func SortedPayloads() []*Payload {

--- a/pkg/handlers/httpx/stop_test.go
+++ b/pkg/handlers/httpx/stop_test.go
@@ -2,7 +2,9 @@ package httpx
 
 import (
 	"context"
+	"errors"
 	"net"
+	"net/http"
 	"testing"
 	"time"
 
@@ -44,6 +46,40 @@ func TestStopUnblocksStart(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("Start did not return within 2s of Stop")
+	}
+}
+
+func TestStopShutsDownHTTPSServerPair(t *testing.T) {
+	// Boot two bound *http.Server instances on free loopback ports
+	// (no Serve call — Shutdown on an unstarted server still returns
+	// cleanly), then assert Stop tears down both as well as the plain
+	// HTTP one and reports the first failure if any.
+	h := NewHandler(map[string]string{"listener": "127.0.0.1:0"}).(*Handler)
+
+	httpAddr := freeTCPAddr(t)
+	httpsAddr := freeTCPAddr(t)
+
+	httpSrv := &http.Server{Addr: httpAddr}
+	httpsSrv := &http.Server{Addr: httpsAddr}
+	challenge := &http.Server{Addr: freeTCPAddr(t)}
+
+	h.mu.Lock()
+	h.httpServer = httpSrv
+	h.httpChallengeServer = challenge
+	h.httpsServer = httpsSrv
+	h.mu.Unlock()
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop = %v, want nil", err)
+	}
+
+	// A second Shutdown after Stop should be a no-op error (the server
+	// is closed). Use it as a marker that Stop actually called Shutdown.
+	for _, s := range []*http.Server{httpSrv, challenge, httpsSrv} {
+		err := s.Shutdown(context.Background())
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("server should be in shutdown state after Stop, got %v", err)
+		}
 	}
 }
 

--- a/pkg/types/interfaces.go
+++ b/pkg/types/interfaces.go
@@ -31,6 +31,15 @@ type Handler interface {
 	Stop(ctx context.Context) error
 }
 
+// Seeder is an optional interface implemented by handlers that need
+// to populate their own database state (e.g. payload templates)
+// before any requests are served. App.Run calls Seed on each
+// implementing handler exactly once, after the DB is connected and
+// before any Start. Seed must be idempotent.
+type Seeder interface {
+	Seed() error
+}
+
 type Notifier interface {
 	Name() string
 	Send(InteractionEvent) error

--- a/pkg/xodbox/run.go
+++ b/pkg/xodbox/run.go
@@ -29,6 +29,19 @@ func NewApp(config *Config) *App {
 		newApp.RegisterNotificationHandler(notifier)
 	}
 
+	// Give every handler that implements types.Seeder a chance to
+	// populate its own DB state. Done here (not in Run) so non-Run
+	// entry points like `xodbox payload dump` still see the seeded
+	// payload set.
+	for _, h := range config.Handlers {
+		if s, ok := h.(types.Seeder); ok {
+			lg().Debug("seeding handler", "handler", h.Name())
+			if err := s.Seed(); err != nil {
+				lg().Error("handler seed failed", "handler", h.Name(), "err", err)
+			}
+		}
+	}
+
 	return newApp
 }
 

--- a/pkg/xodbox/seeder_test.go
+++ b/pkg/xodbox/seeder_test.go
@@ -1,0 +1,82 @@
+package xodbox
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+type seederHandler struct {
+	stoppableHandler
+	seeded int32
+	err    error
+}
+
+func (s *seederHandler) Seed() error {
+	atomic.AddInt32(&s.seeded, 1)
+	return s.err
+}
+
+func TestNewAppCallsSeederOnImplementingHandlers(t *testing.T) {
+	seeded := &seederHandler{
+		stoppableHandler: stoppableHandler{
+			started: make(chan struct{}),
+			wait:    make(chan struct{}),
+		},
+	}
+	plain := &stoppableHandler{
+		started: make(chan struct{}),
+		wait:    make(chan struct{}),
+	}
+
+	_ = NewApp(&Config{Handlers: []types.Handler{seeded, plain}})
+
+	if got := atomic.LoadInt32(&seeded.seeded); got != 1 {
+		t.Errorf("seeded.Seed call count = %d, want 1", got)
+	}
+}
+
+func TestNewAppContinuesOnSeedError(t *testing.T) {
+	bad := &seederHandler{
+		stoppableHandler: stoppableHandler{
+			started: make(chan struct{}),
+			wait:    make(chan struct{}),
+		},
+		err: errors.New("seed boom"),
+	}
+	good := &seederHandler{
+		stoppableHandler: stoppableHandler{
+			started: make(chan struct{}),
+			wait:    make(chan struct{}),
+		},
+	}
+
+	_ = NewApp(&Config{Handlers: []types.Handler{bad, good}})
+
+	if atomic.LoadInt32(&good.seeded) != 1 {
+		t.Error("a Seeder that errors should not stop later seeders from running")
+	}
+}
+
+func TestSeederContract(t *testing.T) {
+	// Compile-time assertion that *seederHandler satisfies types.Seeder.
+	var _ types.Seeder = (*seederHandler)(nil)
+}
+
+// Make sure stoppableHandler still has the right shape after the
+// shutdown_test additions — the Seed method should not conflict.
+func TestSeederStopShape(t *testing.T) {
+	s := &seederHandler{
+		stoppableHandler: stoppableHandler{
+			started: make(chan struct{}),
+			wait:    make(chan struct{}),
+		},
+	}
+	// Stop() is inherited from stoppableHandler — must still work.
+	if err := s.Stop(context.Background()); err != nil {
+		t.Errorf("Stop returned %v, want nil", err)
+	}
+}


### PR DESCRIPTION
httpx/payload.go: the "ghetto if statement" dispatching
InternalFnInspect / InternalFnBuild is replaced with a map[string]
internalFn dispatch table at the bottom of the file. The function
signature `internalFn(w, e, *Handler) error` is uniform across both
entries; Inspect (which doesn't need the handler) is adapted via a
short closure. Adding a new internal_function name is now a one-line
map insertion, so the TODO predicting "if more than 3 blocks" no
longer applies.

types/interfaces.go: new optional Seeder interface

  type Seeder interface { Seed() error }

with documented semantics — called exactly once, idempotent, runs
before Start.

httpx/handler.go: NewHandler no longer hard-codes Seed(model.DB());
instead, *httpx.Handler implements Seeder via a Seed method that
delegates to the package-level Seed function (which is itself gated
by a `seeded` bool, so it remains idempotent across calls).

xodbox/run.go: NewApp now iterates config.Handlers and calls Seed()
on each handler that implements types.Seeder. This is done in NewApp
rather than Run so that non-Run entry points like `xodbox payload
dump` still get the bundled payloads in the DB (regression spotted
during testing).

Tests:
- pkg/xodbox/seeder_test.go: NewApp calls Seed on implementers,
  continues past Seeders that return errors, and the compile-time
  contract is asserted.

Full suite passes under -race; golangci-lint clean.