### PR TITLE
Make SMB advertised target name configurable

### DIFF
--- a/pkg/handlers/smb/_index.md
+++ b/pkg/handlers/smb/_index.md
@@ -48,6 +48,7 @@ verified and no shares are served.
 | `handler`  | yes      | —       | Must be `SMB`.                                                |
 | `listener` | no       | `:445`  | Bind address. Binding `:445` usually needs elevated privileges. |
 | `persist`  | no       | `false` | Must be the literal string `"true"` to save captured hashes to the database (the `interactions` table). Off by default because captured NetNTLMv2 hashes are crackable credential material sitting on disk. |
+| `target_name` | no    | `XODBOX` | The NetBIOS/DNS name advertised in the NTLMSSP challenge (target name + AV pairs). Set a realistic value (e.g. `CORP-FS01`) to blend in and avoid fingerprinting the server as xodbox. Cosmetic — it only affects what the client believes it connected to. |
 
 ## Events
 
@@ -70,8 +71,9 @@ survives restarts and appears in the web view.
 
 - Only NTLMv2 is captured. LM-only / NTLMv1 clients (rare, and usually
   disabled) are logged and skipped.
-- The advertised target name is the cosmetic constant `XODBOX`; it only
-  affects what the client believes it connected to.
+- The advertised target name defaults to `XODBOX` and is configurable via
+  `target_name`; it only affects what the client believes it connected to,
+  so set a realistic value to avoid fingerprinting.
 - No SMB library is vendored — the minimal SMB2/NTLMSSP/SPNEGO wire format
   is implemented in-package, so the handler adds no dependencies.
 - The accept loop returns from `Start()` cleanly when `Stop()` closes the

--- a/pkg/handlers/smb/handler.go
+++ b/pkg/handlers/smb/handler.go
@@ -20,6 +20,7 @@ type Handler struct {
 	name            string
 	Listener        string
 	Persist         bool
+	TargetName      string
 	dispatchChannel chan types.InteractionEvent
 
 	mu       sync.Mutex
@@ -35,10 +36,16 @@ func NewHandler(handlerConfig map[string]string) types.Handler {
 		listener = ":445"
 	}
 
+	targetName := handlerConfig["target_name"]
+	if targetName == "" {
+		targetName = defaultTargetName
+	}
+
 	return &Handler{
-		name:     "SMB",
-		Listener: listener,
-		Persist:  handlerConfig["persist"] == "true",
+		name:       "SMB",
+		Listener:   listener,
+		Persist:    handlerConfig["persist"] == "true",
+		TargetName: targetName,
 	}
 }
 
@@ -187,7 +194,7 @@ func (h *Handler) handleSessionSetup(c net.Conn, done <-chan struct{}, msg []byt
 	switch ntlmMessageType(ntlm) {
 	case ntlmNegotiate:
 		// Client kicked off NTLM: hand back our challenge and ask for more.
-		secBuf := buildNegTokenResp(buildChallenge())
+		secBuf := buildNegTokenResp(buildChallenge(h.TargetName))
 		resp := buildSessionSetupResponse(mid, statusMoreProcessingReqd, secBuf)
 		if err := writePacket(c, resp); err != nil {
 			return true

--- a/pkg/handlers/smb/handler_test.go
+++ b/pkg/handlers/smb/handler_test.go
@@ -39,12 +39,22 @@ func TestDefaultListener(t *testing.T) {
 	if h.Persist {
 		t.Error("persist should default to false")
 	}
+	if h.TargetName != defaultTargetName {
+		t.Errorf("default target name = %q, want %q", h.TargetName, defaultTargetName)
+	}
 }
 
 func TestPersistParsedFromConfig(t *testing.T) {
 	h := NewHandler(map[string]string{"persist": "true"}).(*Handler)
 	if !h.Persist {
 		t.Error("persist=true config should enable persistence")
+	}
+}
+
+func TestTargetNameParsedFromConfig(t *testing.T) {
+	h := NewHandler(map[string]string{"target_name": "CORP-FS01"}).(*Handler)
+	if h.TargetName != "CORP-FS01" {
+		t.Errorf("target name = %q, want CORP-FS01", h.TargetName)
 	}
 }
 

--- a/pkg/handlers/smb/ntlm.go
+++ b/pkg/handlers/smb/ntlm.go
@@ -46,10 +46,11 @@ const (
 	msvAvDNSDomain   = 0x0004
 )
 
-// targetName is the fake NetBIOS/DNS name the server advertises. It only
-// affects what the client believes it is talking to and shows up in the
-// AV pairs; it is not security-sensitive.
-const targetName = "XODBOX"
+// defaultTargetName is the fake NetBIOS/DNS name the server advertises when
+// none is configured. It only affects what the client believes it is
+// talking to and shows up in the AV pairs; it is not security-sensitive,
+// but it is fingerprintable, so operators can override it via config.
+const defaultTargetName = "XODBOX"
 
 // isNTLMSSP reports whether b begins with the NTLMSSP signature.
 func isNTLMSSP(b []byte) bool {
@@ -95,10 +96,10 @@ func avPair(buf *bytes.Buffer, id uint16, value []byte) {
 }
 
 // buildChallenge builds an NTLMSSP CHALLENGE (type 2) message carrying
-// ServerChallenge and a synthetic target info block. This is the token
-// the server hands back inside SESSION_SETUP to make the client compute
-// and send its NetNTLMv2 response.
-func buildChallenge() []byte {
+// ServerChallenge and a synthetic target info block built from targetName.
+// This is the token the server hands back inside SESSION_SETUP to make the
+// client compute and send its NetNTLMv2 response.
+func buildChallenge(targetName string) []byte {
 	tn := utf16le(targetName)
 
 	var info bytes.Buffer

--- a/pkg/handlers/smb/ntlm_test.go
+++ b/pkg/handlers/smb/ntlm_test.go
@@ -98,13 +98,13 @@ func TestParseAuthenticateRejectsShortNT(t *testing.T) {
 }
 
 func TestParseAuthenticateRejectsWrongType(t *testing.T) {
-	if _, err := parseAuthenticate(buildChallenge()); err == nil {
+	if _, err := parseAuthenticate(buildChallenge(defaultTargetName)); err == nil {
 		t.Error("expected error parsing a CHALLENGE as an AUTHENTICATE")
 	}
 }
 
 func TestBuildChallengeIsWellFormed(t *testing.T) {
-	ch := buildChallenge()
+	ch := buildChallenge(defaultTargetName)
 	if ntlmMessageType(ch) != ntlmChallenge {
 		t.Fatalf("message type = %d, want %d", ntlmMessageType(ch), ntlmChallenge)
 	}
@@ -121,11 +121,14 @@ func TestBuildChallengeIsWellFormed(t *testing.T) {
 // (NT_STATUS_BUFFER_TOO_SMALL). It resolves the payloads via the field
 // descriptors exactly as a client would.
 func TestBuildChallengePayloadOffsets(t *testing.T) {
-	ch := buildChallenge()
+	// Use a custom target name to also prove it flows through into the
+	// advertised AV pairs (configurable to avoid fingerprinting).
+	const customName = "CORP-FS01"
+	ch := buildChallenge(customName)
 
-	// TargetNameFields @12 must resolve to our advertised target name.
-	if got := fromUTF16le(field(ch, 12)); got != targetName {
-		t.Errorf("TargetName via declared offset = %q, want %q", got, targetName)
+	// TargetNameFields @12 must resolve to the configured target name.
+	if got := fromUTF16le(field(ch, 12)); got != customName {
+		t.Errorf("TargetName via declared offset = %q, want %q", got, customName)
 	}
 
 	// TargetInfoFields @40 must resolve to a well-formed AV_PAIR list that
@@ -212,7 +215,7 @@ func TestSelectDialectShortRequest(t *testing.T) {
 }
 
 func TestFindNTLMSSPInSPNEGO(t *testing.T) {
-	challenge := buildChallenge()
+	challenge := buildChallenge(defaultTargetName)
 	wrapped := buildNegTokenResp(challenge)
 	found := findNTLMSSP(wrapped)
 	if !bytes.Equal(found, challenge) {

--- a/pkg/xodbox/config/xodbox.yaml
+++ b/pkg/xodbox/config/xodbox.yaml
@@ -21,6 +21,7 @@ handlers:
 #  - handler: SMB
 #    listener: :445 # fake SMB server; captures NetNTLMv2 hashes (hashcat mode 5600)
 #    persist: true # save captured hashes to the database (off by default)
+#    target_name: CORP-FS01 # advertised NetBIOS/DNS name (default XODBOX); customize to avoid fingerprinting
 ## Docs: https://defektive.github.io/xodbox/docs/pkg/notifiers/
 notifiers:
 #  ## Docs: https://defektive.github.io/xodbox/docs/pkg/notifiers/slack/


### PR DESCRIPTION
The NTLMSSP challenge advertised a hardcoded "XODBOX" target name, which fingerprints the fake server. Add a `target_name` handler config key (default "XODBOX") threaded into buildChallenge so operators can set a realistic name (e.g. CORP-FS01) and blend in.

Document the key in the handler docs and embedded config, and cover default and custom values with tests.