### PR TITLE
Unify notifier filtering on a canonical cross-handler match string

### DIFF
--- a/pkg/handlers/dns/handler.go
+++ b/pkg/handlers/dns/handler.go
@@ -70,6 +70,20 @@ func (e *Event) Details() string {
 	return fmt.Sprintf("DNS: %s", qq)
 }
 
+// FilterString returns "DNS <QTYPE> <qname> from <ip>", e.g.
+// "DNS A c2.evil.com. from 10.0.0.5".
+func (e *Event) FilterString() string {
+	qtype, qname := "", ""
+	for _, q := range e.msg.Question {
+		if q.Name != "" {
+			qtype = dns.TypeToString[q.Qtype]
+			qname = q.Name
+			break
+		}
+	}
+	return fmt.Sprintf("DNS %s %s from %s", qtype, qname, e.RemoteAddr)
+}
+
 func (h *Handler) dispatchEvent(w dns.ResponseWriter, req *dns.Msg) {
 	e := newEvent(w, req)
 	h.dispatchChannel <- e

--- a/pkg/handlers/ftp/event.go
+++ b/pkg/handlers/ftp/event.go
@@ -66,3 +66,9 @@ func NewEvent(remoteAddr string, action Action) *Event {
 func (e *Event) Details() string {
 	return fmt.Sprintf("FTP: event from %s", e.RemoteAddr)
 }
+
+// FilterString returns "FTP <ACTION> from <ip>", e.g.
+// "FTP AuthSuccess from 10.0.0.5".
+func (e *Event) FilterString() string {
+	return fmt.Sprintf("FTP %s from %s", e.action, e.RemoteAddr)
+}

--- a/pkg/handlers/httpx/event.go
+++ b/pkg/handlers/httpx/event.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 	"sync"
 	"time"
 
@@ -64,6 +65,14 @@ func NewEvent(req *http.Request) *Event {
 
 func (e *Event) Details() string {
 	return fmt.Sprintf("HTTPX: %s %s from %s", e.req.Method, e.req.URL.String(), e.req.RemoteAddr)
+}
+
+// FilterString returns "HTTPX <METHOD> <path?query> from <ip-chain>". The
+// IP chain is the unique X-Forwarded-For + peer list, so filters can select
+// on method, path, or any hop's source IP.
+func (e *Event) FilterString() string {
+	return fmt.Sprintf("HTTPX %s %s from %s",
+		e.req.Method, e.req.URL.RequestURI(), strings.Join(util.RequestIPChain(e.req), ","))
 }
 
 func (e *Event) Body() []byte {

--- a/pkg/handlers/httpx/filter_test.go
+++ b/pkg/handlers/httpx/filter_test.go
@@ -1,0 +1,26 @@
+package httpx
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+func TestFilterStringWithForwardedChain(t *testing.T) {
+	req := &http.Request{
+		Method:     "POST",
+		URL:        &url.URL{Path: "/x/beacon", RawQuery: "id=1"},
+		RemoteAddr: "10.0.0.1:5000",
+		Header:     http.Header{},
+	}
+	req.Header.Set("X-Forwarded-For", "203.0.113.9, 198.51.100.2")
+
+	e := &Event{BaseEvent: &types.BaseEvent{}, req: req}
+
+	want := "HTTPX POST /x/beacon?id=1 from 203.0.113.9,198.51.100.2,10.0.0.1"
+	if got := e.FilterString(); got != want {
+		t.Errorf("FilterString =\n  %q\nwant\n  %q", got, want)
+	}
+}

--- a/pkg/handlers/smb/event.go
+++ b/pkg/handlers/smb/event.go
@@ -38,6 +38,15 @@ func (e *Event) Details() string {
 	return fmt.Sprintf("SMB Interaction Event: %s %d %s", e.RemoteAddr, e.RemotePortNumber, e.action.String())
 }
 
+// FilterString returns "SMB <ACTION> [account] from <ip>", e.g.
+// "SMB Auth CORP\\alice from 10.0.0.5".
+func (e *Event) FilterString() string {
+	if e.action == Auth && e.Account != "" {
+		return fmt.Sprintf("SMB %s %s from %s", e.action, e.Account, e.RemoteAddr)
+	}
+	return fmt.Sprintf("SMB %s from %s", e.action, e.RemoteAddr)
+}
+
 // Dispatch sends the concrete *Event (not the embedded *BaseEvent) onto
 // the channel so notifiers see this type's Details()/Data().
 func (e *Event) Dispatch(cc chan types.InteractionEvent) {

--- a/pkg/handlers/smb/filter_test.go
+++ b/pkg/handlers/smb/filter_test.go
@@ -1,0 +1,34 @@
+package smb
+
+import (
+	"net"
+	"testing"
+)
+
+func TestFilterString(t *testing.T) {
+	c := &fakeConn{remote: "10.0.0.5:445"}
+
+	auth := NewEvent(c, Auth, []byte("alice::CORP:..."))
+	auth.Account = "CORP\\alice"
+	if got := auth.FilterString(); got != "SMB Auth CORP\\alice from 10.0.0.5" {
+		t.Errorf("Auth FilterString = %q", got)
+	}
+
+	conn := NewEvent(c, Connect, nil)
+	if got := conn.FilterString(); got != "SMB Connect from 10.0.0.5" {
+		t.Errorf("Connect FilterString = %q", got)
+	}
+}
+
+// fakeConn is a minimal net.Conn stand-in exposing a RemoteAddr.
+type fakeConn struct {
+	net.Conn
+	remote string
+}
+
+func (f *fakeConn) RemoteAddr() net.Addr { return fakeAddr(f.remote) }
+
+type fakeAddr string
+
+func (a fakeAddr) Network() string { return "tcp" }
+func (a fakeAddr) String() string  { return string(a) }

--- a/pkg/handlers/smtp/event.go
+++ b/pkg/handlers/smtp/event.go
@@ -50,6 +50,12 @@ func (e *Event) Details() string {
 	return fmt.Sprintf("SMTP: %s from %s", e.action, e.RemoteAddr)
 }
 
+// FilterString returns "SMTP <ACTION> from <ip>", e.g.
+// "SMTP Mail from 10.0.0.5".
+func (e *Event) FilterString() string {
+	return fmt.Sprintf("SMTP %s from %s", e.action, e.RemoteAddr)
+}
+
 func NewEvent(ctx *SMTPSession, action Action) *Event {
 	hostname, portNum := util.GetHostAndPortFromRemoteAddr(ctx.conn.Conn().RemoteAddr().String())
 

--- a/pkg/handlers/ssh/event.go
+++ b/pkg/handlers/ssh/event.go
@@ -41,6 +41,12 @@ func (e *Event) Details() string {
 	return fmt.Sprintf("SSH: %s from %s (%s)", e.action, e.user, e.RemoteAddr)
 }
 
+// FilterString returns "SSH <ACTION> <user> from <ip>", e.g.
+// "SSH PasswordAuth root from 10.0.0.5".
+func (e *Event) FilterString() string {
+	return fmt.Sprintf("SSH %s %s from %s", e.action, e.user, e.RemoteAddr)
+}
+
 func NewEvent(ctx ssh.Context, action Action) *Event {
 	hostname, portNum := util.GetHostAndPortFromRemoteAddr(ctx.RemoteAddr().String())
 

--- a/pkg/handlers/tcp/event.go
+++ b/pkg/handlers/tcp/event.go
@@ -32,6 +32,12 @@ func (e *Event) Details() string {
 	return fmt.Sprintf("TCP Interaction Event: %s %d %s", e.RemoteAddr, e.RemotePortNumber, e.action.String())
 }
 
+// FilterString returns "TCP <ACTION> from <ip>", e.g.
+// "TCP Data from 10.0.0.5".
+func (e *Event) FilterString() string {
+	return fmt.Sprintf("TCP %s from %s", e.action.String(), e.RemoteAddr)
+}
+
 func NewEvent(ctx net.Conn, action Action, packet []byte) *Event {
 	hostname, portNum := util.GetHostAndPortFromRemoteAddr(ctx.RemoteAddr().String())
 

--- a/pkg/notifiers/_index.md
+++ b/pkg/notifiers/_index.md
@@ -8,6 +8,46 @@ Notifiers are used to send notifications to external services or log interaction
 
 ### Filters
 
-Each notifier will accept a `filter` configuration option. This option will be compiled into a golang regexp object. What it is executed against depends on the event it is executing against. For HTTPX events it will be the entire HTTP request. This would be a simple example of matching a specific path prefix `(GET|POST|HEAD|DELETE|PUT|PATCH|TRACE) /x/`.
+Each notifier accepts a `filter` configuration option, compiled into a Go
+regexp. The notifier only fires when the filter matches — this applies to
+every notifier (`app_log`, `slack`, `discord`, `webhook`). The default
+filter is `.*` (match everything).
 
-Be sure to check each [handler](../handlers) for mor information on what it's event supplies for filter matching.
+The regexp is matched against a single **canonical string** that is
+consistent across every handler:
+
+```
+HANDLER ACTION DETAIL from IP[,IP...]
+```
+
+- **HANDLER** — the handler name (`HTTPX`, `DNS`, `FTP`, `SMTP`, `SSH`,
+  `TCP`, `SMB`).
+- **ACTION** — the interaction kind (HTTP method, DNS query type, `Auth`,
+  `Mail`, `Data`, …).
+- **DETAIL** — handler-specific specifics (HTTP path+query, DNS name, SSH
+  user, SMB account, …).
+- **IP chain** — the unique source IPs. For HTTPX this is the
+  de-duplicated `X-Forwarded-For` + `X-Real-Ip` + peer chain (client
+  first); for other handlers it's the peer IP.
+
+Because the shape is uniform, one regexp can select across any handler:
+
+| Goal | Filter |
+|------|--------|
+| HTTP payload hits under `/x/` | `^HTTPX (GET\|POST) /x/` |
+| Captured SMB hashes | `^SMB Auth` |
+| DNS lookups for a C2 domain | `^DNS (A\|AAAA) .*\.evil\.com` |
+| SSH login attempts as root | `^SSH \w+ root ` |
+| Anything from one source IP | `from .*10\.0\.0\.5` |
+
+Example canonical strings:
+
+```
+HTTPX POST /x/beacon?id=1 from 203.0.113.9,10.0.0.1
+DNS A c2.evil.com. from 10.0.0.5
+SMB Auth CORP\alice from 10.0.0.5
+SSH PasswordAuth root from 10.0.0.5
+```
+
+Check each [handler](../handlers) for the exact `FilterString` its events
+produce.

--- a/pkg/notifiers/app_log/notifier_log.go
+++ b/pkg/notifiers/app_log/notifier_log.go
@@ -34,6 +34,9 @@ func (wh *Notifier) Payload(e types.InteractionEvent) (string, []any) {
 }
 
 func (wh *Notifier) Send(e types.InteractionEvent) error {
+	if !wh.filter.MatchString(e.FilterString()) {
+		return nil
+	}
 	msg, args := wh.Payload(e)
 	lg().Info(msg, args...)
 	return nil

--- a/pkg/notifiers/discord/notifier.go
+++ b/pkg/notifiers/discord/notifier.go
@@ -49,7 +49,7 @@ func (wh *Notifier) Payload(e types.InteractionEvent) ([]byte, error) {
 }
 
 func (wh *Notifier) Send(event types.InteractionEvent) error {
-	if webhook.FilterMatches(wh.Filter(), event.Data()) {
+	if webhook.FilterMatches(wh.Filter(), event.FilterString()) {
 		jsonBody, err := wh.Payload(event)
 		if err != nil {
 			lg().Error("error marshaling JSON", "err", err)

--- a/pkg/notifiers/slack/notifier.go
+++ b/pkg/notifiers/slack/notifier.go
@@ -54,7 +54,7 @@ func (wh *Notifier) Payload(e types.InteractionEvent) ([]byte, error) {
 }
 
 func (wh *Notifier) Send(event types.InteractionEvent) error {
-	if webhook.FilterMatches(wh.Filter(), event.Data()) {
+	if webhook.FilterMatches(wh.Filter(), event.FilterString()) {
 		jsonBody, err := wh.Payload(event)
 		if err != nil {
 			lg().Error("error marshaling JSON", "err", err)

--- a/pkg/notifiers/webhook/gate_test.go
+++ b/pkg/notifiers/webhook/gate_test.go
@@ -1,0 +1,53 @@
+package webhook
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+// filterEvent is a minimal InteractionEvent whose FilterString is fixed and
+// whose Data differs, proving the notifier gates on FilterString.
+type filterEvent struct {
+	*types.BaseEvent
+	fs string
+}
+
+func (e filterEvent) FilterString() string { return e.fs }
+
+func TestSendGatesOnFilterString(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+	}))
+	defer srv.Close()
+
+	n := NewNotifier(srv.URL, "^SMB Auth")
+
+	// Data() says "SMB Auth ..." but FilterString() says DNS — must NOT send,
+	// proving the gate uses FilterString, not Data.
+	nonMatch := filterEvent{
+		BaseEvent: &types.BaseEvent{RawData: []byte("SMB Auth CORP\\alice")},
+		fs:        "DNS A evil.com from 1.2.3.4",
+	}
+	if err := n.Send(nonMatch); err != nil {
+		t.Fatalf("Send(nonMatch) = %v", err)
+	}
+	if atomic.LoadInt32(&hits) != 0 {
+		t.Fatalf("non-matching event was sent (hits=%d)", hits)
+	}
+
+	match := filterEvent{
+		BaseEvent: &types.BaseEvent{},
+		fs:        "SMB Auth CORP\\alice from 10.0.0.5",
+	}
+	if err := n.Send(match); err != nil {
+		t.Fatalf("Send(match) = %v", err)
+	}
+	if atomic.LoadInt32(&hits) != 1 {
+		t.Fatalf("matching event not sent (hits=%d)", hits)
+	}
+}

--- a/pkg/notifiers/webhook/notifier.go
+++ b/pkg/notifiers/webhook/notifier.go
@@ -38,6 +38,9 @@ func (wh *Notifier) Filter() *regexp.Regexp {
 }
 
 func (wh *Notifier) Send(event types.InteractionEvent) error {
+	if !FilterMatches(wh.filter, event.FilterString()) {
+		return nil
+	}
 	jsonBody, err := wh.Payload(event)
 	if err != nil {
 		lg().Error("error marshaling JSON", "err", err)

--- a/pkg/types/base_event.go
+++ b/pkg/types/base_event.go
@@ -27,6 +27,17 @@ func (e *BaseEvent) Data() string {
 	return string(e.RawData)
 }
 
+// FilterString is the fallback match target for events that don't override
+// it. Concrete handler events replace this with a canonical
+// "HANDLER ACTION DETAIL from IP" string; the base default just exposes the
+// raw data and source IP so a bare event is still filterable.
+func (e *BaseEvent) FilterString() string {
+	if e.RemoteAddr == "" {
+		return e.Data()
+	}
+	return e.Data() + " from " + e.RemoteAddr
+}
+
 func (e *BaseEvent) Dispatch(cc chan InteractionEvent) {
 	go func() {
 		cc <- e

--- a/pkg/types/interfaces.go
+++ b/pkg/types/interfaces.go
@@ -17,6 +17,13 @@ type InteractionEvent interface {
 	RemotePort() int
 	UserAgent() string
 	Data() string
+	// FilterString returns the canonical, handler-labelled string a
+	// notifier's Filter regex is matched against. It has the shape
+	// "HANDLER ACTION DETAIL from IP[,IP...]" (e.g. "SMB Auth CORP\\alice
+	// from 10.0.0.5"), so a single regex can select across every handler
+	// (e.g. "^SMB Auth", "^DNS (A|AAAA) .*\\.evil\\.com"). The trailing IP
+	// list is the unique source chain (X-Forwarded-For + peer for HTTP).
+	FilterString() string
 	Dispatch(cc chan InteractionEvent)
 }
 

--- a/pkg/util/host_helpers.go
+++ b/pkg/util/host_helpers.go
@@ -39,3 +39,35 @@ func GetHostAndPortFromRemoteAddr(remoteAddr string) (string, int) {
 
 	return parsedURL.Hostname(), portNum
 }
+
+// RequestIPChain returns the unique, order-preserving chain of source IPs
+// for an HTTP request: X-Forwarded-For entries (client first), then
+// X-Real-Ip, then the direct TCP peer. Duplicates are collapsed. Forwarded
+// headers are client-controlled and can be spoofed, so treat the chain as
+// informational rather than authoritative.
+func RequestIPChain(req *http.Request) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(ip string) {
+		ip = strings.TrimSpace(ip)
+		if ip == "" {
+			return
+		}
+		if _, ok := seen[ip]; ok {
+			return
+		}
+		seen[ip] = struct{}{}
+		out = append(out, ip)
+	}
+
+	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
+		for _, p := range strings.Split(xff, ",") {
+			add(p)
+		}
+	}
+	add(req.Header.Get("X-Real-Ip"))
+	if host, _ := GetHostAndPortFromRemoteAddr(req.RemoteAddr); host != "" {
+		add(host)
+	}
+	return out
+}

--- a/pkg/util/ip_chain_test.go
+++ b/pkg/util/ip_chain_test.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRequestIPChain(t *testing.T) {
+	cases := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		realIP     string
+		want       string
+	}{
+		{
+			name:       "peer only",
+			remoteAddr: "10.0.0.5:44321",
+			want:       "10.0.0.5",
+		},
+		{
+			name:       "x-forwarded-for chain then peer",
+			remoteAddr: "10.0.0.1:5000",
+			xff:        "203.0.113.9, 198.51.100.2",
+			want:       "203.0.113.9,198.51.100.2,10.0.0.1",
+		},
+		{
+			name:       "dedup peer already in chain",
+			remoteAddr: "203.0.113.9:5000",
+			xff:        "203.0.113.9, 198.51.100.2",
+			want:       "203.0.113.9,198.51.100.2",
+		},
+		{
+			name:       "x-real-ip included and deduped",
+			remoteAddr: "10.0.0.1:5000",
+			xff:        "203.0.113.9",
+			realIP:     "203.0.113.9",
+			want:       "203.0.113.9,10.0.0.1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &http.Request{RemoteAddr: tc.remoteAddr, Header: http.Header{}}
+			if tc.xff != "" {
+				req.Header.Set("X-Forwarded-For", tc.xff)
+			}
+			if tc.realIP != "" {
+				req.Header.Set("X-Real-Ip", tc.realIP)
+			}
+			if got := strings.Join(RequestIPChain(req), ","); got != tc.want {
+				t.Errorf("RequestIPChain = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/xodbox/config/xodbox.yaml
+++ b/pkg/xodbox/config/xodbox.yaml
@@ -30,11 +30,11 @@ notifiers:
 #    channel: general
 #    author: PirateVirus
 #    author_image: ':pirate:'
-#    filter: "(GET|POST|HEAD|DELETE|PUT|PATCH|TRACE) /x/"
+#    filter: "^HTTPX (GET|POST|HEAD|DELETE|PUT|PATCH|TRACE) /x/" # regex vs "HANDLER ACTION DETAIL from IP" (e.g. "^SMB Auth", "^DNS (A|AAAA) .*\\.evil\\.com")
 #  ## Docs: https://defektive.github.io/xodbox/docs/pkg/notifiers/discord/
 #  - notifier: discord
 #    url: https://discord.com/api/webhooks/133...6C
 #    author: PirateVirus
 #    author_image: https://s3-us-west-2.amazonaws.com/slack-f...72.png
-#    filter: "(GET|POST|HEAD|DELETE|PUT|PATCH|TRACE) /x/"
+#    filter: "^HTTPX (GET|POST|HEAD|DELETE|PUT|PATCH|TRACE) /x/" # regex vs "HANDLER ACTION DETAIL from IP" (e.g. "^SMB Auth", "^DNS (A|AAAA) .*\\.evil\\.com")
   - notifier: app_log


### PR DESCRIPTION
Notifier filters were matched against event.Data(), which is HTTP-shaped and inconsistent across handlers — FTP/SMTP/SSH have empty Data() (so they were silently unfilterable), and there was no way to route by handler or action. app_log and webhook also ignored their filter entirely.

Add FilterString() to InteractionEvent: a canonical "HANDLER ACTION DETAIL from IP[,IP...]" string implemented by every handler, so one regex selects across all of them (e.g. "^SMB Auth", "^DNS (A|AAAA) .*\.evil\.com"). HTTPX includes the unique X-Forwarded-For/X-Real-Ip/peer IP chain via a new util.RequestIPChain.

Route all notifiers (app_log, slack, discord, webhook) through FilterString, fixing the ignored-filter and empty-Data gaps. Update the example config filters and the notifiers filter docs, and add tests for the IP chain, per-handler FilterString, and the filter gate.