### PR TITLE
Exempt private/loopback sources from HTTP bot suppression

### DIFF
--- a/pkg/handlers/httpx/_index.md
+++ b/pkg/handlers/httpx/_index.md
@@ -26,8 +26,12 @@ asserted against expected paths and headers.
   internet.
 - Bot suppression: clients that exceed 30 requests in any one-minute
   bucket are marked as bots (`model.IsBot`) and have their subsequent
-  events suppressed from notifier delivery. The bot threshold is not
-  configurable today.
+  events suppressed from notifier delivery (logged at `WARN`). The
+  threshold itself is not configurable today. Loopback, RFC1918 private,
+  and link-local sources are **exempt** from this suppression by default —
+  they're usually the operator testing or an internal SSRF callback — so a
+  burst of local/internal traffic won't silently mute your notifiers. Set
+  `bot_exempt_private: "false"` to subject every source to bot detection.
 - The private API (mounted at `api_path`) requires the header
   `Authorization: Token <api_token>` on every request. An empty
   `api_token` rejects all callers.
@@ -45,6 +49,7 @@ asserted against expected paths and headers.
 | `payload_dir`  | no       | —       | Directory of `*.md` payload definitions. Watched at runtime; updates are upserted.     |
 | `api_path`     | no       | —       | URL path prefix to mount the JSON API on, e.g. `/api`. Normalised to leading/trailing slash. |
 | `api_token`    | no       | —       | Bearer-style token required by the `/private/*` API routes.                            |
+| `bot_exempt_private` | no | `true` | Exempt loopback/private/link-local sources from volume-based bot suppression. Set to `"false"` to apply bot detection to every source. |
 
 ### TLS / ACME
 

--- a/pkg/handlers/httpx/bot_config_test.go
+++ b/pkg/handlers/httpx/bot_config_test.go
@@ -1,0 +1,23 @@
+package httpx
+
+import "testing"
+
+func TestBotExemptPrivateConfig(t *testing.T) {
+	// Default: exemption on.
+	h := NewHandler(map[string]string{"listener": ":0"}).(*Handler)
+	if !h.BotExemptPrivate {
+		t.Error("bot_exempt_private should default to true")
+	}
+
+	// Explicit "false" disables it.
+	off := NewHandler(map[string]string{"listener": ":0", "bot_exempt_private": "false"}).(*Handler)
+	if off.BotExemptPrivate {
+		t.Error(`bot_exempt_private: "false" should disable exemption`)
+	}
+
+	// Any other value keeps the default (on).
+	on := NewHandler(map[string]string{"listener": ":0", "bot_exempt_private": "true"}).(*Handler)
+	if !on.BotExemptPrivate {
+		t.Error(`bot_exempt_private: "true" should enable exemption`)
+	}
+}

--- a/pkg/handlers/httpx/event.go
+++ b/pkg/handlers/httpx/event.go
@@ -17,9 +17,10 @@ import (
 
 type Event struct {
 	*types.BaseEvent
-	req           *http.Request
-	body          []byte
-	requestHeader []byte
+	req              *http.Request
+	body             []byte
+	requestHeader    []byte
+	botExemptPrivate bool
 }
 
 func NewEvent(req *http.Request) *Event {
@@ -37,9 +38,10 @@ func NewEvent(req *http.Request) *Event {
 			UserAgentString:  req.UserAgent(),
 			RawData:          dump,
 		},
-		req:           req,
-		body:          body,
-		requestHeader: dump,
+		req:              req,
+		body:             body,
+		requestHeader:    dump,
+		botExemptPrivate: true,
 	}
 	protocol := "http"
 	if req.TLS != nil {
@@ -96,13 +98,21 @@ func (e *Event) RemoteAddr() string {
 }
 
 func (e *Event) Dispatch(cc chan types.InteractionEvent) {
-	if model.IsBot(e.BaseEvent.RemoteAddr) {
-		lg().Info("not dispatching bot", "remote addr", e.BaseEvent.RemoteAddr)
-	} else {
-		go func() {
-			cc <- e
-		}()
+	addr := e.BaseEvent.RemoteAddr
+
+	// Loopback/private sources are usually the operator or an internal SSRF
+	// callback, so (when enabled) they bypass volume-based bot detection —
+	// otherwise a burst of local testing or captures silently stops
+	// dispatching and every notifier goes quiet.
+	exempt := e.botExemptPrivate && util.IsPrivateOrLoopback(addr)
+	if !exempt && model.IsBot(addr) {
+		lg().Warn("not dispatching suspected bot (high request volume); set bot_exempt_private to exempt local/private sources", "remote_addr", addr)
+		return
 	}
+
+	go func() {
+		cc <- e
+	}()
 }
 
 func (e *Event) TemplateContext(templateData map[string]string) *TemplateContext {

--- a/pkg/handlers/httpx/event_test.go
+++ b/pkg/handlers/httpx/event_test.go
@@ -104,7 +104,8 @@ func TestEventDispatchNonBot(t *testing.T) {
 }
 
 func TestEventDispatchBotSuppressed(t *testing.T) {
-	const botIP = "10.0.0.99"
+	// Public IP: not exempt, so volume-based bot detection still applies.
+	const botIP = "203.0.113.99"
 
 	// Seed >30 interactions for botIP so model.IsBot returns true.
 	for i := 0; i < 31; i++ {
@@ -126,6 +127,43 @@ func TestEventDispatchBotSuppressed(t *testing.T) {
 		t.Errorf("bot should be suppressed, got event %+v", evt)
 	case <-time.After(200 * time.Millisecond):
 		// expected: nothing delivered
+	}
+}
+
+func TestEventDispatchPrivateExemptFromBot(t *testing.T) {
+	// A private IP that trips bot detection should still dispatch when
+	// bot_exempt_private is on (the default), and be suppressed when off.
+	const botIP = "10.0.0.77"
+	for i := 0; i < 31; i++ {
+		model.DB().Create(&model.Interaction{RemoteAddr: botIP, Handler: "test"})
+	}
+	if !model.IsBot(botIP) {
+		t.Fatalf("precondition: model.IsBot(%q) should be true", botIP)
+	}
+
+	r := newPOSTRequest(t, "http://example.com/", "")
+	r.RemoteAddr = botIP + ":12345"
+
+	// Exempt (default): dispatched despite bot volume.
+	e := NewEvent(r) // botExemptPrivate defaults true
+	ch := make(chan types.InteractionEvent, 1)
+	e.Dispatch(ch)
+	select {
+	case <-ch: // expected
+	case <-time.After(200 * time.Millisecond):
+		t.Error("private source should be exempt from bot detection and dispatch")
+	}
+
+	// Exemption disabled: suppressed like any other bot.
+	e2 := NewEvent(r)
+	e2.botExemptPrivate = false
+	ch2 := make(chan types.InteractionEvent, 1)
+	e2.Dispatch(ch2)
+	select {
+	case evt := <-ch2:
+		t.Errorf("with exemption off, private bot should be suppressed, got %+v", evt)
+	case <-time.After(200 * time.Millisecond):
+		// expected
 	}
 }
 

--- a/pkg/handlers/httpx/handler.go
+++ b/pkg/handlers/httpx/handler.go
@@ -44,6 +44,7 @@ type Handler struct {
 	TLSNames           []string
 	APIPath            string
 	APIToken           string
+	BotExemptPrivate   bool
 
 	StaticDir       string
 	dispatchChannel chan types.InteractionEvent
@@ -75,6 +76,12 @@ func NewHandler(handlerConfig map[string]string) types.Handler {
 	mdaasAllowedCIDR := handlerConfig["mdaas_allowed_cidr"]
 	mdaasNotifyURL := handlerConfig["mdaas_notify_url"]
 
+	// Exempt loopback/private/link-local sources from volume-based bot
+	// detection by default — those are usually the operator or an internal
+	// SSRF callback, and dropping them silently is a foot-gun. Set
+	// bot_exempt_private: "false" to subject every source to bot detection.
+	botExemptPrivate := handlerConfig["bot_exempt_private"] != "false"
+
 	tlsNames := []string{}
 	if tlsNamesOpt != "" {
 		tlsNames = strings.Split(tlsNamesOpt, ",")
@@ -98,6 +105,7 @@ func NewHandler(handlerConfig map[string]string) types.Handler {
 		MDaaSNotifyURL:     mdaasNotifyURL,
 		APIPath:            handlerConfig["api_path"],
 		APIToken:           handlerConfig["api_token"],
+		BotExemptPrivate:   botExemptPrivate,
 	}
 
 	if payloadDir != "" {
@@ -162,6 +170,7 @@ func (h *Handler) serverMux() *http.ServeMux {
 				lg().Debug("http response completed", "timeTaken", fmt.Sprintf("%dµs", time.Since(loadStart).Microseconds()))
 			}()
 			e := NewEvent(r)
+			e.botExemptPrivate = h.BotExemptPrivate
 			e.Dispatch(h.dispatchChannel)
 
 			for _, payload := range SortedPayloads() {
@@ -358,6 +367,7 @@ func (h *Handler) noIndex(next http.Handler) http.Handler {
 		}
 
 		e := NewEvent(r)
+		e.botExemptPrivate = h.BotExemptPrivate
 		e.Dispatch(h.dispatchChannel)
 
 		next.ServeHTTP(w, r)

--- a/pkg/util/host_helpers.go
+++ b/pkg/util/host_helpers.go
@@ -2,11 +2,24 @@ package util
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 )
+
+// IsPrivateOrLoopback reports whether host is a loopback, RFC1918 private,
+// or link-local IP address. host should be a bare IP (no port); non-IP
+// hostnames return false. Used to exempt trusted/local sources (operators
+// testing, internal SSRF callbacks) from volume-based bot detection.
+func IsPrivateOrLoopback(host string) bool {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
+}
 
 func GetRemoteAddrFromRequest(req *http.Request) string {
 

--- a/pkg/util/ip_private_test.go
+++ b/pkg/util/ip_private_test.go
@@ -1,0 +1,24 @@
+package util
+
+import "testing"
+
+func TestIsPrivateOrLoopback(t *testing.T) {
+	cases := map[string]bool{
+		"127.0.0.1":      true,  // loopback
+		"::1":            true,  // loopback v6
+		"10.0.0.5":       true,  // RFC1918
+		"192.168.1.10":   true,  // RFC1918
+		"172.16.0.1":     true,  // RFC1918
+		"169.254.10.1":   true,  // link-local
+		"203.0.113.9":    false, // public
+		"8.8.8.8":        false, // public
+		"":               false, // not an IP
+		"example.com":    false, // hostname
+		"not-an-ip:1234": false, // includes port / not bare IP
+	}
+	for host, want := range cases {
+		if got := IsPrivateOrLoopback(host); got != want {
+			t.Errorf("IsPrivateOrLoopback(%q) = %v, want %v", host, got, want)
+		}
+	}
+}

--- a/pkg/xodbox/config/xodbox.yaml
+++ b/pkg/xodbox/config/xodbox.yaml
@@ -16,6 +16,7 @@ handlers:
 #    dns_provider: namecheap # or route53
 #    dns_provider_api_user: namecheap-user
 #    dns_provider_api_key: namecheap-secret
+#    bot_exempt_private: "false" # apply bot detection to local/private IPs too (default exempts them)
     listener: :80
   ## Docs: https://defektive.github.io/xodbox/docs/pkg/handlers/smb/
 #  - handler: SMB


### PR DESCRIPTION
httpx drops events from any source exceeding 30 req/min (model.IsBot) before they reach notifiers. That silently muted all notifications during local testing and — worse for this tool — for internal SSRF callbacks, which typically come from a single private IP.

Exempt loopback, RFC1918, and link-local sources from bot suppression by default, configurable via the new bot_exempt_private handler key ("false" applies detection to every source). Also raise the drop log from INFO to WARN with a message naming the knob, so the behavior is diagnosable.

Add util.IsPrivateOrLoopback, thread the flag through to Event.Dispatch, and cover exemption on/off, config parsing, and the helper with tests. Document the knob in the handler docs and embedded config.