### PR TITLE
feat(xodbox): drop-list to silence noisy callouts + interactions purge

### DIFF
--- a/pkg/cmd/interactions.go
+++ b/pkg/cmd/interactions.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/defektive/xodbox/pkg/model"
+	"github.com/spf13/cobra"
+)
+
+var (
+	purgeRemotes []string
+	purgeTarget  string
+	purgeHandler string
+	purgeDryRun  bool
+)
+
+var interactionsCmd = &cobra.Command{
+	Use:   "interactions",
+	Short: "Inspect and prune recorded interactions.",
+	Long: "Manage the interactions the listeners have recorded. Use 'purge' to " +
+		"remove noise from a known source (e.g. a leftover beacon from an old " +
+		"test) that has been flooding the database.",
+}
+
+var interactionsPurgeCmd = &cobra.Command{
+	Use:   "purge",
+	Short: "Delete recorded interactions matching a source, target, or handler.",
+	Long: "Delete interactions matching the given filters (ANDed together). At " +
+		"least one filter is required so the whole table isn't wiped by mistake. " +
+		"Pair this with the ignore_cidrs / ignore_pattern config defaults to stop " +
+		"the same noisy callout from being recorded going forward.\n\n" +
+		"Examples:\n" +
+		"  xodbox interactions purge --remote 203.0.113.7\n" +
+		"  xodbox interactions purge --remote 10.0.0.0/8 --dry-run\n" +
+		"  xodbox interactions purge --target /old-test-callback --handler httpx",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		f := model.InteractionPurgeFilter{
+			Remotes: purgeRemotes,
+			Target:  purgeTarget,
+			Handler: purgeHandler,
+		}
+
+		if purgeDryRun {
+			matched, err := model.MatchingInteractions(f)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "dry-run: %d interaction(s) match; nothing deleted\n", len(matched))
+			return nil
+		}
+
+		n, err := model.PurgeInteractions(f)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "deleted %d interaction(s)\n", n)
+		return nil
+	},
+}
+
+func init() {
+	interactionsPurgeCmd.Flags().StringSliceVar(&purgeRemotes, "remote", nil, "source IP or CIDR to purge (repeatable, comma-separated)")
+	interactionsPurgeCmd.Flags().StringVar(&purgeTarget, "target", "", "substring matched against the request target (HTTP path / DNS qname)")
+	interactionsPurgeCmd.Flags().StringVar(&purgeHandler, "handler", "", "restrict to a single handler (e.g. httpx, dns)")
+	interactionsPurgeCmd.Flags().BoolVar(&purgeDryRun, "dry-run", false, "report how many rows match without deleting")
+	interactionsCmd.AddCommand(interactionsPurgeCmd)
+	XodboxCmd.AddCommand(interactionsCmd)
+}

--- a/pkg/handlers/httpx/event.go
+++ b/pkg/handlers/httpx/event.go
@@ -117,7 +117,12 @@ func (e *Event) NotifySuppressed() bool {
 	addr := e.BaseEvent.RemoteAddr
 	exempt := e.botExemptPrivate && util.IsPrivateOrLoopback(addr)
 	if !exempt && model.IsBot(addr) {
-		lg().Warn("suppressing notifiers for suspected bot (high request volume); still recorded. Set bot_exempt_private to exempt local/private sources", "remote_addr", addr)
+		// Debug (not Warn) and throttled per source: a bot calling many times a
+		// second would otherwise emit one log line per request. The traffic is
+		// still recorded; only the notification is suppressed.
+		if botSuppressLog.allow(addr) {
+			lg().Debug("suppressing notifiers for suspected bot (high request volume); still recorded. Set bot_exempt_private to exempt local/private sources", "remote_addr", addr)
+		}
 		return true
 	}
 	return false

--- a/pkg/handlers/httpx/log_throttle.go
+++ b/pkg/handlers/httpx/log_throttle.go
@@ -1,0 +1,52 @@
+package httpx
+
+import (
+	"sync"
+	"time"
+)
+
+// throttleMaxKeys bounds the per-key timestamp map so a scanner cycling through
+// many source IPs can't grow it without limit. When exceeded, stale entries
+// (older than the throttle interval) are pruned opportunistically.
+const throttleMaxKeys = 1024
+
+// logThrottle rate-limits repetitive log lines per key (e.g. per source IP), so
+// a high-volume source doesn't emit one line per request even at debug level.
+type logThrottle struct {
+	mu       sync.Mutex
+	last     map[string]time.Time
+	interval time.Duration
+}
+
+func newLogThrottle(interval time.Duration) *logThrottle {
+	return &logThrottle{last: map[string]time.Time{}, interval: interval}
+}
+
+// allow reports whether a message for key may be emitted now. It returns true
+// at most once per interval per key, recording the emit time when it does.
+func (t *logThrottle) allow(key string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := time.Now()
+	if prev, ok := t.last[key]; ok && now.Sub(prev) < t.interval {
+		return false
+	}
+
+	// Prune stale entries before inserting a new key once the map grows large,
+	// so distinct-IP floods don't leak memory.
+	if len(t.last) > throttleMaxKeys {
+		for k, ts := range t.last {
+			if now.Sub(ts) >= t.interval {
+				delete(t.last, k)
+			}
+		}
+	}
+
+	t.last[key] = now
+	return true
+}
+
+// botSuppressLog throttles the suspected-bot suppression line to at most once
+// per source per minute.
+var botSuppressLog = newLogThrottle(time.Minute)

--- a/pkg/handlers/httpx/log_throttle_test.go
+++ b/pkg/handlers/httpx/log_throttle_test.go
@@ -1,0 +1,54 @@
+package httpx
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLogThrottleAllowsOncePerInterval(t *testing.T) {
+	tr := newLogThrottle(time.Minute)
+
+	if !tr.allow("1.2.3.4") {
+		t.Fatal("first call for a key should be allowed")
+	}
+	if tr.allow("1.2.3.4") {
+		t.Error("second call within the interval should be throttled")
+	}
+	// A different key is independent.
+	if !tr.allow("5.6.7.8") {
+		t.Error("first call for a distinct key should be allowed")
+	}
+}
+
+func TestLogThrottleAllowsAgainAfterInterval(t *testing.T) {
+	tr := newLogThrottle(10 * time.Millisecond)
+
+	if !tr.allow("1.2.3.4") {
+		t.Fatal("first call should be allowed")
+	}
+	time.Sleep(15 * time.Millisecond)
+	if !tr.allow("1.2.3.4") {
+		t.Error("call after the interval elapsed should be allowed again")
+	}
+}
+
+func TestLogThrottlePrunesStaleKeys(t *testing.T) {
+	tr := newLogThrottle(5 * time.Millisecond)
+
+	// Fill past the prune threshold with keys that will go stale.
+	for i := 0; i < throttleMaxKeys+10; i++ {
+		tr.allow(string(rune(i)) + "-a")
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	// This insert crosses the threshold and should trigger a prune of the now
+	// stale entries above.
+	tr.allow("trigger-prune")
+
+	tr.mu.Lock()
+	size := len(tr.last)
+	tr.mu.Unlock()
+	if size > throttleMaxKeys {
+		t.Errorf("map not pruned: size %d > cap %d", size, throttleMaxKeys)
+	}
+}

--- a/pkg/model/interactions.go
+++ b/pkg/model/interactions.go
@@ -1,6 +1,15 @@
 package model
 
-import "gorm.io/gorm"
+import (
+	"errors"
+
+	"github.com/defektive/xodbox/pkg/util"
+	"gorm.io/gorm"
+)
+
+// ErrNoPurgeConstraint is returned when a purge is attempted with no filter
+// constraint, which would match (and delete) every interaction.
+var ErrNoPurgeConstraint = errors.New("refusing to purge with no filter (specify --remote, --target, or --handler)")
 
 type Interaction struct {
 	gorm.Model
@@ -59,4 +68,101 @@ func IsBot(remoteAddr string) bool {
 		Find(&results)
 
 	return len(results) > 0
+}
+
+// InteractionPurgeFilter selects interactions to delete. Fields are ANDed
+// together; a zero-value filter matches everything, so callers must supply at
+// least one constraint (enforced by Matches returning false for an empty
+// filter) to avoid nuking the whole table by accident.
+type InteractionPurgeFilter struct {
+	// Remotes is a list of source IPs/CIDRs; an interaction whose RemoteAddr
+	// falls in any of them matches. Empty means "any source".
+	Remotes []string
+	// Target is a case-sensitive substring matched against RequestTarget
+	// (the HTTP path / DNS qname). Empty means "any target".
+	Target string
+	// Handler restricts to a single handler name (e.g. "httpx"). Empty means
+	// "any handler".
+	Handler string
+}
+
+// hasConstraint reports whether the filter narrows anything. A filter with no
+// constraint would match every row, which we refuse to purge silently.
+func (f InteractionPurgeFilter) hasConstraint() bool {
+	return len(f.Remotes) > 0 || f.Target != "" || f.Handler != ""
+}
+
+// MatchingInteractions returns the interactions the filter selects, applying
+// the SQL-expressible constraints (handler, target substring) in the query and
+// the CIDR match in Go (SQLite can't do CIDR containment). Returns an error if
+// the filter has no constraint, or if any Remotes entry is an invalid CIDR/IP.
+func MatchingInteractions(f InteractionPurgeFilter) ([]Interaction, error) {
+	if !f.hasConstraint() {
+		return nil, ErrNoPurgeConstraint
+	}
+
+	nets, err := util.ParseCIDRs(joinNonEmpty(f.Remotes))
+	if err != nil {
+		return nil, err
+	}
+
+	q := DB().Model(&Interaction{})
+	if f.Handler != "" {
+		q = q.Where("handler = ?", f.Handler)
+	}
+	if f.Target != "" {
+		q = q.Where("request_target LIKE ?", "%"+f.Target+"%")
+	}
+
+	var rows []Interaction
+	if err := q.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	if len(nets) == 0 {
+		return rows, nil
+	}
+
+	var matched []Interaction
+	for _, r := range rows {
+		if util.IPInAny(r.RemoteAddr, nets) {
+			matched = append(matched, r)
+		}
+	}
+	return matched, nil
+}
+
+// PurgeInteractions deletes the interactions the filter selects and returns the
+// number removed. See MatchingInteractions for filter semantics and errors.
+func PurgeInteractions(f InteractionPurgeFilter) (int64, error) {
+	matched, err := MatchingInteractions(f)
+	if err != nil {
+		return 0, err
+	}
+	if len(matched) == 0 {
+		return 0, nil
+	}
+
+	ids := make([]uint, len(matched))
+	for i, r := range matched {
+		ids[i] = r.ID
+	}
+	tx := DB().Where("id IN ?", ids).Delete(&Interaction{})
+	return tx.RowsAffected, tx.Error
+}
+
+// joinNonEmpty joins entries with commas so ParseCIDRs can split them back
+// out; entries may themselves already be comma-separated.
+func joinNonEmpty(parts []string) string {
+	out := ""
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		if out != "" {
+			out += ","
+		}
+		out += p
+	}
+	return out
 }

--- a/pkg/model/interactions_purge_test.go
+++ b/pkg/model/interactions_purge_test.go
@@ -1,0 +1,82 @@
+package model
+
+import (
+	"errors"
+	"testing"
+)
+
+func seedInteraction(t *testing.T, ix Interaction) {
+	t.Helper()
+	if err := DB().Create(&ix).Error; err != nil {
+		t.Fatalf("seed interaction: %v", err)
+	}
+}
+
+func TestPurgeInteractionsRequiresConstraint(t *testing.T) {
+	if _, err := MatchingInteractions(InteractionPurgeFilter{}); !errors.Is(err, ErrNoPurgeConstraint) {
+		t.Errorf("empty filter error = %v, want ErrNoPurgeConstraint", err)
+	}
+	if _, err := PurgeInteractions(InteractionPurgeFilter{}); !errors.Is(err, ErrNoPurgeConstraint) {
+		t.Errorf("empty filter purge error = %v, want ErrNoPurgeConstraint", err)
+	}
+}
+
+func TestPurgeInteractionsByCIDR(t *testing.T) {
+	// Unique target keeps this test's rows isolated from the shared package DB.
+	const target = "/purge-cidr-test"
+	seedInteraction(t, Interaction{Handler: "httpx", RemoteAddr: "198.51.100.5", RequestTarget: target})
+	seedInteraction(t, Interaction{Handler: "httpx", RemoteAddr: "198.51.100.6", RequestTarget: target})
+	seedInteraction(t, Interaction{Handler: "httpx", RemoteAddr: "8.8.8.8", RequestTarget: target})
+
+	f := InteractionPurgeFilter{Remotes: []string{"198.51.100.0/24"}, Target: target}
+
+	matched, err := MatchingInteractions(f)
+	if err != nil {
+		t.Fatalf("MatchingInteractions: %v", err)
+	}
+	if len(matched) != 2 {
+		t.Fatalf("matched %d rows, want 2", len(matched))
+	}
+
+	n, err := PurgeInteractions(f)
+	if err != nil {
+		t.Fatalf("PurgeInteractions: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("deleted %d rows, want 2", n)
+	}
+
+	// The 8.8.8.8 row must survive.
+	var remaining int64
+	DB().Model(&Interaction{}).Where("request_target = ?", target).Count(&remaining)
+	if remaining != 1 {
+		t.Errorf("remaining rows = %d, want 1 (the non-matching source)", remaining)
+	}
+}
+
+func TestPurgeInteractionsByTargetAndHandler(t *testing.T) {
+	const target = "/purge-target-test-beacon"
+	seedInteraction(t, Interaction{Handler: "httpx", RemoteAddr: "192.0.2.10", RequestTarget: target})
+	seedInteraction(t, Interaction{Handler: "dns", RemoteAddr: "192.0.2.11", RequestTarget: target})
+
+	// Handler filter should scope the delete to httpx only.
+	n, err := PurgeInteractions(InteractionPurgeFilter{Target: "purge-target-test-beacon", Handler: "httpx"})
+	if err != nil {
+		t.Fatalf("PurgeInteractions: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("deleted %d rows, want 1", n)
+	}
+
+	var remaining int64
+	DB().Model(&Interaction{}).Where("request_target = ?", target).Count(&remaining)
+	if remaining != 1 {
+		t.Errorf("remaining rows = %d, want 1 (the dns row)", remaining)
+	}
+}
+
+func TestPurgeInteractionsInvalidCIDR(t *testing.T) {
+	if _, err := PurgeInteractions(InteractionPurgeFilter{Remotes: []string{"nonsense"}}); err == nil {
+		t.Error("invalid CIDR should return an error")
+	}
+}

--- a/pkg/util/cidr_test.go
+++ b/pkg/util/cidr_test.go
@@ -1,0 +1,50 @@
+package util
+
+import "testing"
+
+func TestParseCIDRs(t *testing.T) {
+	nets, err := ParseCIDRs(" 10.0.0.0/8 , 203.0.113.7 , ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(nets) != 2 {
+		t.Fatalf("parsed %d nets, want 2 (empty entries skipped)", len(nets))
+	}
+
+	if _, err := ParseCIDRs(""); err != nil {
+		t.Errorf("empty spec should not error: %v", err)
+	}
+
+	if _, err := ParseCIDRs("nonsense"); err == nil {
+		t.Error("invalid entry should error")
+	}
+}
+
+func TestIPInAny(t *testing.T) {
+	nets, err := ParseCIDRs("10.0.0.0/8,203.0.113.7,2001:db8::/32")
+	if err != nil {
+		t.Fatalf("ParseCIDRs: %v", err)
+	}
+
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"10.1.2.3", true},
+		{"203.0.113.7", true},
+		{"203.0.113.8", false},
+		{"2001:db8::1", true},
+		{"2001:dead::1", false},
+		{"8.8.8.8", false},
+		{"not-an-ip", false},
+	}
+	for _, c := range cases {
+		if got := IPInAny(c.ip, nets); got != c.want {
+			t.Errorf("IPInAny(%q) = %v, want %v", c.ip, got, c.want)
+		}
+	}
+
+	if IPInAny("10.0.0.1", nil) {
+		t.Error("empty net list should never match")
+	}
+}

--- a/pkg/util/host_helpers.go
+++ b/pkg/util/host_helpers.go
@@ -21,6 +21,52 @@ func IsPrivateOrLoopback(host string) bool {
 	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
 }
 
+// ParseCIDRs parses a comma-separated list of CIDRs and bare IPs into
+// networks. A bare IP (e.g. "1.2.3.4" or "2001:db8::1") is treated as a
+// single-host network (/32 or /128). Empty entries and surrounding
+// whitespace are ignored; an empty spec yields a nil slice and no error.
+// The first unparseable entry returns an error so config mistakes surface
+// loudly rather than silently matching nothing.
+func ParseCIDRs(spec string) ([]*net.IPNet, error) {
+	var nets []*net.IPNet
+	for _, raw := range strings.Split(spec, ",") {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		if !strings.Contains(entry, "/") {
+			if ip := net.ParseIP(entry); ip != nil {
+				bits := 32
+				if ip.To4() == nil {
+					bits = 128
+				}
+				entry = fmt.Sprintf("%s/%d", entry, bits)
+			}
+		}
+		_, network, err := net.ParseCIDR(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR/IP %q: %w", strings.TrimSpace(raw), err)
+		}
+		nets = append(nets, network)
+	}
+	return nets, nil
+}
+
+// IPInAny reports whether host (a bare IP, no port) falls within any of the
+// given networks. A non-IP host or an empty network list returns false.
+func IPInAny(host string, nets []*net.IPNet) bool {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	for _, n := range nets {
+		if n != nil && n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
 func GetRemoteAddrFromRequest(req *http.Request) string {
 
 	ra := req.RemoteAddr

--- a/pkg/xodbox/config/xodbox.yaml
+++ b/pkg/xodbox/config/xodbox.yaml
@@ -1,4 +1,15 @@
 ---
+## Global defaults. Uncommenting this block overrides ALL defaults, so keep the
+## notify_string/server_name lines if you set it.
+#defaults:
+#  notify_string: l
+#  server_name: BreakfastBot
+#  ## Drop events from noisy sources entirely (no DB row, no notification, no log
+#  ## line). Use these to silence a known callout — e.g. a leftover beacon from an
+#  ## old test that keeps calling back every second. An event matching EITHER rule
+#  ## is dropped. Prune already-recorded rows with: xodbox interactions purge
+#  ignore_cidrs: "203.0.113.7,10.0.0.0/8" # comma-separated source IPs/CIDRs to drop
+#  ignore_pattern: "^HTTPX GET /old-test-callback" # regex vs "HANDLER ACTION DETAIL from IP"
 ## Docs: https://defektive.github.io/xodbox/docs/pkg/handlers/
 handlers:
   ## Docs: https://defektive.github.io/xodbox/docs/pkg/handlers/dns/

--- a/pkg/xodbox/ignore.go
+++ b/pkg/xodbox/ignore.go
@@ -1,0 +1,77 @@
+package xodbox
+
+import (
+	"net"
+	"regexp"
+
+	"github.com/defektive/xodbox/pkg/types"
+	"github.com/defektive/xodbox/pkg/util"
+)
+
+// Config keys (under `defaults:`) for the global ignore/drop list. An event
+// matching either rule is discarded before it is persisted or dispatched to
+// notifiers — no DB row, no notification, no log line. Use this to silence a
+// known-noisy source (e.g. a leftover beacon from an old test that keeps
+// calling back every second) without muting the rest of your traffic.
+const (
+	// IgnoreCIDRsKey is a comma-separated list of source IPs/CIDRs to drop.
+	IgnoreCIDRsKey = "ignore_cidrs"
+	// IgnorePatternKey is a regex matched against the event FilterString
+	// ("HANDLER ACTION DETAIL from IP[,IP...]"), so it can select on handler,
+	// method, path, or source IP — e.g. "^HTTPX GET /old-test-callback".
+	IgnorePatternKey = "ignore_pattern"
+)
+
+// ignoreRule decides whether an inbound event should be dropped entirely.
+// A nil *ignoreRule matches nothing, so callers can hold one unconditionally.
+type ignoreRule struct {
+	cidrs   []*net.IPNet
+	pattern *regexp.Regexp
+}
+
+// newIgnoreRule builds an ignoreRule from the app defaults map. It returns a
+// non-nil rule even when nothing is configured (Matches then always reports
+// false). A malformed CIDR list or regex is returned as an error so the
+// operator sees the misconfiguration at startup instead of silently dropping
+// or keeping everything.
+func newIgnoreRule(defaults map[string]string) (*ignoreRule, error) {
+	r := &ignoreRule{}
+
+	cidrs, err := util.ParseCIDRs(defaults[IgnoreCIDRsKey])
+	if err != nil {
+		return nil, err
+	}
+	r.cidrs = cidrs
+
+	if pat := defaults[IgnorePatternKey]; pat != "" {
+		re, err := regexp.Compile(pat)
+		if err != nil {
+			return nil, err
+		}
+		r.pattern = re
+	}
+
+	return r, nil
+}
+
+// active reports whether any rule is configured. Used to skip logging setup
+// when the ignore list is empty (the common case).
+func (r *ignoreRule) active() bool {
+	return r != nil && (len(r.cidrs) > 0 || r.pattern != nil)
+}
+
+// Matches reports whether e should be dropped. Source IP is checked against
+// the CIDR list; the FilterString is checked against the pattern. Either hit
+// drops the event.
+func (r *ignoreRule) Matches(e types.InteractionEvent) bool {
+	if r == nil || e == nil {
+		return false
+	}
+	if len(r.cidrs) > 0 && util.IPInAny(e.RemoteIP(), r.cidrs) {
+		return true
+	}
+	if r.pattern != nil && r.pattern.MatchString(e.FilterString()) {
+		return true
+	}
+	return false
+}

--- a/pkg/xodbox/ignore_test.go
+++ b/pkg/xodbox/ignore_test.go
@@ -1,0 +1,84 @@
+package xodbox
+
+import (
+	"testing"
+
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+func TestNewIgnoreRuleEmptyIsInactive(t *testing.T) {
+	r, err := newIgnoreRule(map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.active() {
+		t.Error("empty defaults should produce an inactive rule")
+	}
+	if r.Matches(&types.BaseEvent{RemoteAddr: "1.2.3.4"}) {
+		t.Error("inactive rule must not match anything")
+	}
+}
+
+func TestIgnoreRuleCIDRMatch(t *testing.T) {
+	r, err := newIgnoreRule(map[string]string{
+		IgnoreCIDRsKey: "10.0.0.0/8, 203.0.113.7",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !r.active() {
+		t.Fatal("rule with cidrs should be active")
+	}
+
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"10.1.2.3", true},    // inside CIDR
+		{"203.0.113.7", true}, // bare IP → /32
+		{"203.0.113.8", false},
+		{"8.8.8.8", false},
+		{"not-an-ip", false},
+	}
+	for _, c := range cases {
+		if got := r.Matches(&types.BaseEvent{RemoteAddr: c.addr}); got != c.want {
+			t.Errorf("Matches(%q) = %v, want %v", c.addr, got, c.want)
+		}
+	}
+}
+
+func TestIgnoreRulePatternMatch(t *testing.T) {
+	// BaseEvent.FilterString() is "<data> from <ip>", so drive the pattern off
+	// the RawData payload.
+	r, err := newIgnoreRule(map[string]string{
+		IgnorePatternKey: "^beacon-callback",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !r.Matches(&types.BaseEvent{RawData: []byte("beacon-callback"), RemoteAddr: "8.8.8.8"}) {
+		t.Error("event matching the pattern should be dropped")
+	}
+	if r.Matches(&types.BaseEvent{RawData: []byte("legit-traffic"), RemoteAddr: "8.8.8.8"}) {
+		t.Error("event not matching the pattern should be kept")
+	}
+}
+
+func TestIgnoreRuleInvalidConfig(t *testing.T) {
+	if _, err := newIgnoreRule(map[string]string{IgnoreCIDRsKey: "not-a-cidr"}); err == nil {
+		t.Error("invalid CIDR should return an error")
+	}
+	if _, err := newIgnoreRule(map[string]string{IgnorePatternKey: "("}); err == nil {
+		t.Error("invalid regex should return an error")
+	}
+}
+
+func TestIgnoreRuleNilSafe(t *testing.T) {
+	var r *ignoreRule
+	if r.active() {
+		t.Error("nil rule should be inactive")
+	}
+	if r.Matches(&types.BaseEvent{RemoteAddr: "1.2.3.4"}) {
+		t.Error("nil rule must not match")
+	}
+}

--- a/pkg/xodbox/run.go
+++ b/pkg/xodbox/run.go
@@ -23,11 +23,24 @@ const persistQueueSize = 1024
 
 func NewApp(config *Config) *App {
 
+	// Build the global ignore/drop list from defaults. A bad CIDR or regex is
+	// fatal: silently dropping (or keeping) everything is worse than failing
+	// loudly at startup.
+	ignore, err := newIgnoreRule(config.TemplateData)
+	if err != nil {
+		lg().Error("invalid ignore rule in config defaults", "err", err)
+		os.Exit(1)
+	}
+	if ignore.active() {
+		lg().Info("global ignore list active; matching events will be dropped (not persisted or notified)")
+	}
+
 	newApp := &App{
 		appConfig:            config,
 		eventChan:            make(chan types.InteractionEvent),
 		persistChan:          make(chan types.InteractionEvent, persistQueueSize),
 		notificationHandlers: []types.Notifier{},
+		ignore:               ignore,
 		stop:                 make(chan struct{}),
 	}
 
@@ -57,6 +70,10 @@ type App struct {
 	eventChan            chan types.InteractionEvent
 	persistChan          chan types.InteractionEvent
 	notificationHandlers []types.Notifier
+
+	// ignore drops events from configured noisy sources before they are
+	// persisted or dispatched. Never nil (newIgnoreRule always returns a rule).
+	ignore *ignoreRule
 
 	// stop is closed once by Shutdown to unblock waitForEvents.
 	stop chan struct{}
@@ -163,6 +180,14 @@ func (x *App) waitForEvents() {
 			lg().Debug("event loop shutting down")
 			return
 		case newEvent := <-x.eventChan:
+			// Drop events from configured noisy sources entirely: no DB row, no
+			// notification, no log spam. This is the escape hatch for a known
+			// callout (e.g. a leftover beacon hammering the server every second)
+			// that would otherwise flood both the Events log and the database.
+			if x.ignore.Matches(newEvent) {
+				lg().Debug("ignoring event (matched ignore list)", "details", newEvent.Details())
+				continue
+			}
 			// Hand the event to the persister (non-blocking so a write backlog
 			// can't stall the loop), then dispatch to notifiers — unless the
 			// event opts out of notification (e.g. a suspected bot), which stays

--- a/pkg/xodbox/run_ignore_test.go
+++ b/pkg/xodbox/run_ignore_test.go
@@ -1,0 +1,64 @@
+package xodbox
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/defektive/xodbox/pkg/model"
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+// TestAppDropsIgnoredEvents verifies that an event whose source matches the
+// configured ignore list is neither persisted nor sent to notifiers, while a
+// non-matching event flowing right behind it is processed normally.
+func TestAppDropsIgnoredEvents(t *testing.T) {
+	const ignoredIP = "203.0.113.200"
+	const keptIP = "203.0.113.201"
+
+	n := &recordingNotifier{}
+	app := NewApp(&Config{
+		TemplateData: map[string]string{IgnoreCIDRsKey: ignoredIP},
+		Notifiers:    []types.Notifier{n},
+		Handlers:     []types.Handler{},
+	})
+	go app.Run()
+
+	ignoredFilter := model.InteractionFilter{Handler: "tcp", RemoteAddr: ignoredIP}
+	before := model.CountInteractions(ignoredFilter)
+
+	app.eventChan <- &persistableEvent{
+		BaseEvent: &types.BaseEvent{RemoteAddr: ignoredIP},
+		rec:       &model.Interaction{Handler: "tcp", RemoteAddr: ignoredIP},
+	}
+	// A kept event behind the ignored one; once its notifier fires we know the
+	// loop has moved past the ignored event.
+	app.eventChan <- &persistableEvent{
+		BaseEvent: &types.BaseEvent{RemoteAddr: keptIP},
+		rec:       &model.Interaction{Handler: "tcp", RemoteAddr: keptIP},
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && atomic.LoadInt32(&n.hits) < 1 {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The kept event should have reached the notifier exactly once; the ignored
+	// event must not have.
+	if got := atomic.LoadInt32(&n.hits); got != 1 {
+		t.Fatalf("notifier hits = %d, want 1 (only the kept event)", got)
+	}
+	n.mu.Lock()
+	for _, e := range n.events {
+		if e.RemoteIP() == ignoredIP {
+			t.Errorf("notifier received ignored event from %s", ignoredIP)
+		}
+	}
+	n.mu.Unlock()
+
+	// Give the persister time, then confirm the ignored event was not stored.
+	time.Sleep(150 * time.Millisecond)
+	if got := model.CountInteractions(ignoredFilter); got != before {
+		t.Errorf("ignored event was persisted: count %d -> %d", before, got)
+	}
+}


### PR DESCRIPTION
A leftover beacon from an old test could keep calling back every second,
flooding both the Events log and the SQLite database. The existing bot
detection only mutes notifiers (and still persists every hit, and warns
once per suppressed event), so there was no way to fully silence a known
noisy source.

Add a global, config-driven ignore/drop list evaluated once in the app
event loop, so it covers every handler (HTTP, DNS, SMTP, ...):

- defaults.ignore_cidrs: comma-separated source IPs/CIDRs
- defaults.ignore_pattern: regex matched against the event FilterString
  ("HANDLER ACTION DETAIL from IP")

An event matching either rule is dropped before persistence and before
notifier dispatch — no DB row, no notification, no log line. A malformed
CIDR/regex fails loudly at startup.

Add `xodbox interactions purge` to prune already-recorded rows by
--remote (IP/CIDR), --target (path substring), and --handler, with
--dry-run. At least one filter is required so the table can't be wiped by
accident. CIDR containment is evaluated in Go since SQLite can't express it.

Shared util.ParseCIDRs / util.IPInAny back both the runtime matcher and
the purge command. Documented the new knobs in the embedded xodbox.yaml.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013x5rj3i9LqcrcPrRRW3vpN