### PR TITLE
Add worker engine for periodic background jobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/libdns/namecheap v1.0.0
 	github.com/libdns/route53 v1.6.2
 	github.com/miekg/dns v1.1.72
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/model/interactions.go
+++ b/pkg/model/interactions.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"errors"
+	"time"
 
 	"github.com/defektive/xodbox/pkg/util"
 	"gorm.io/gorm"
@@ -149,6 +150,18 @@ func PurgeInteractions(f InteractionPurgeFilter) (int64, error) {
 		ids[i] = r.ID
 	}
 	tx := DB().Where("id IN ?", ids).Delete(&Interaction{})
+	return tx.RowsAffected, tx.Error
+}
+
+// PurgeInteractionsOlderThan deletes interactions whose CreatedAt is older
+// than the given number of days. Returns the number of rows deleted.
+// Returns an error if days < 1 to prevent accidentally nuking everything.
+func PurgeInteractionsOlderThan(days int) (int64, error) {
+	if days < 1 {
+		return 0, errors.New("purge: days must be >= 1")
+	}
+	cutoff := time.Now().AddDate(0, 0, -days)
+	tx := DB().Where("created_at < ?", cutoff).Delete(&Interaction{})
 	return tx.RowsAffected, tx.Error
 }
 

--- a/pkg/notifiers/_index.md
+++ b/pkg/notifiers/_index.md
@@ -6,6 +6,8 @@ weight: 10
 
 Notifiers are used to send notifications to external services or log interactions to the app log.
 
+Available notifiers: `app_log`, `slack`, `discord`, `webhook`.
+
 ### Filters
 
 Each notifier accepts a `filter` configuration option, compiled into a Go

--- a/pkg/notifiers/webhook/_index.md
+++ b/pkg/notifiers/webhook/_index.md
@@ -4,9 +4,12 @@ description: Generic HTTP Webhook
 weight: 1
 ---
 
-POSTs every event (or every event whose `Data()` matches `filter`) as
-a JSON object to a configured URL. Slack and Discord notifiers share
-this codepath under the hood.
+POSTs every matching event as a JSON object to a configured URL. Slack
+and Discord notifiers share this codepath under the hood, but `webhook`
+can also be used directly as a standalone notifier — no custom code
+required. This makes it the primary integration point for external
+workflows: pipe NTLM hashes to a cracking service, forward SMB auth
+events to n8n, send everything to a SIEM, etc.
 
 ## Payload shape
 
@@ -16,9 +19,12 @@ this codepath under the hood.
   "RemotePort": 54321,
   "UserAgent":  "curl/8.0",
   "Data":       "DELETE /probe HTTP/1.1\r\nHost: ...",
-  "Details":    "HTTPX: DELETE http://.../probe from 203.0.113.5:54321"
+  "Details":    "HTTPX: DELETE http://.../probe from 203.0.113.5:54321",
+  "Curl":       "curl -X DELETE ..."
 }
 ```
+
+`Curl` is only populated for HTTP events; it is omitted for other handlers.
 
 ## Configuration
 
@@ -26,12 +32,31 @@ this codepath under the hood.
 |------------|----------|---------|--------------------------------------------------------------------------------|
 | `notifier` | yes      | —       | Must be `webhook`.                                                             |
 | `url`      | yes      | —       | Destination URL. Posted with `Content-Type: application/json`.                 |
-| `filter`   | no       | `.*`    | Go `regexp` syntax. Tested against the event's `Data()`; non-matches are dropped silently. |
+| `filter`   | no       | `.*`    | Go `regexp` matched against `"HANDLER ACTION DETAIL from IP"`. See [Notifiers](../) for the full filter reference. |
+
+## Example
+
+```yaml
+notifiers:
+  # Forward every captured SMB hash to an external cracking pipeline.
+  - notifier: webhook
+    url: https://n8n.myteam.internal/webhook/ntlm-capture
+    filter: "^SMB Auth"
+
+  # Alert a SIEM on any /l path hit (the default notify path).
+  - notifier: webhook
+    url: https://siem.example.com/ingest/xodbox
+    filter: "^HTTPX.*\\/l"
+
+  # No filter — forward everything.
+  - notifier: webhook
+    url: https://my-siem.example.com/ingest
+```
 
 ## Failure handling
 
 - 2xx/3xx responses are treated as success.
-- 4xx/5xx responses log an error but do not propagate one up to the
-  dispatcher (so a flaky webhook does not block other notifiers).
+- 4xx/5xx responses log an error but do not propagate it to the
+  dispatcher (a flaky webhook does not block other notifiers).
 - Connection/transport failures (DNS, refused, timeout) propagate as
   errors and are surfaced in the app log.

--- a/pkg/notifiers/webhook/notifier.go
+++ b/pkg/notifiers/webhook/notifier.go
@@ -17,6 +17,13 @@ type Notifier struct {
 	filter *regexp.Regexp
 }
 
+// NewNotifierFromConfig creates a standalone webhook notifier from a YAML
+// config map. Recognized keys: "url" (required), "filter" (optional,
+// defaults to ".*").
+func NewNotifierFromConfig(cfg map[string]string) types.Notifier {
+	return NewNotifier(cfg["url"], cfg["filter"])
+}
+
 func NewNotifier(url string, filter string) *Notifier {
 
 	if filter == "" {

--- a/pkg/types/interfaces.go
+++ b/pkg/types/interfaces.go
@@ -62,6 +62,17 @@ type Notifier interface {
 	Filter() *regexp.Regexp
 }
 
+// Worker is a periodic background job managed by the workflow engine.
+// Schedule is a robfig/cron v3 expression: standard 5-field cron
+// ("0 2 * * *"), shorthand ("@daily"), or interval ("@every 1h").
+// Run is called once per tick; ctx is cancelled on shutdown.
+// An error is logged but does not stop future ticks.
+type Worker interface {
+	Name() string
+	Schedule() string
+	Run(ctx context.Context) error
+}
+
 type NotifierBase struct {
 	Name   string
 	Filter string

--- a/pkg/workers/_index.md
+++ b/pkg/workers/_index.md
@@ -1,0 +1,54 @@
+---
+title: Workers
+description: Periodic background jobs
+weight: 20
+---
+
+Workers are periodic background jobs that run inside the xodbox process
+on a configurable schedule. They are the complement to [Notifiers](../notifiers):
+notifiers react to inbound events in real time; workers run independently
+of traffic and operate on the captured data (pruning old records,
+aggregating stats, etc.).
+
+Workers are registered in `xodbox.yaml` under a top-level `workers:` key,
+following the same `key: value` map convention used by handlers and notifiers.
+
+## Schedule expressions
+
+The `schedule` key accepts any [robfig/cron v3](https://pkg.go.dev/github.com/robfig/cron/v3)
+expression:
+
+| Expression | Meaning |
+|---|---|
+| `@daily` | Once a day at midnight |
+| `@hourly` | Once an hour |
+| `@every 30m` | Every 30 minutes |
+| `@every 6h` | Every 6 hours |
+| `0 2 * * *` | Standard 5-field cron (daily at 02:00) |
+| `*/15 * * * *` | Every 15 minutes |
+
+## Behaviour
+
+- If a worker is still running when its next tick fires, the new tick is
+  **silently skipped** — there is no pileup.
+- A worker error is logged but does not stop the scheduler; the worker
+  will run again on the next tick.
+- Workers are shut down gracefully: on SIGINT/SIGTERM xodbox cancels the
+  context passed to `Run` and waits for any in-flight run to complete
+  before exiting.
+
+## Example
+
+```yaml
+workers:
+  ## Docs: https://defektive.github.io/xodbox/docs/pkg/workers/purge/
+  - worker: purge
+    schedule: "@daily"
+    max_age_days: "30"
+```
+
+## Available workers
+
+| Worker | Description |
+|---|---|
+| [`purge`](purge/) | Delete interactions older than N days |

--- a/pkg/workers/purge/_index.md
+++ b/pkg/workers/purge/_index.md
@@ -1,0 +1,35 @@
+---
+title: Purge
+description: Delete old interactions on a schedule
+weight: 1
+---
+
+Deletes interaction records older than a configurable number of days.
+Run this to keep the SQLite database from growing unbounded during
+long-running engagements.
+
+## Configuration
+
+| Key           | Required | Default  | Notes                                                       |
+|---------------|----------|----------|-------------------------------------------------------------|
+| `worker`      | yes      | —        | Must be `purge`.                                            |
+| `schedule`    | no       | `@daily` | Cron expression or `@every` interval. See [Workers](../).   |
+| `max_age_days`| no       | `30`     | Interactions older than this many days are deleted. Must be ≥ 1. |
+
+## Example
+
+```yaml
+workers:
+  # Delete interactions older than 14 days, every night at 02:00.
+  - worker: purge
+    schedule: "0 2 * * *"
+    max_age_days: "14"
+```
+
+## Notes
+
+- Uses GORM soft-delete (sets `deleted_at`), so the rows are not
+  immediately reclaimed by SQLite. Run `VACUUM` manually if you need to
+  shrink the file on disk after a large purge.
+- `max_age_days: "0"` is rejected with an error to prevent accidentally
+  deleting everything.

--- a/pkg/workers/purge/logging.go
+++ b/pkg/workers/purge/logging.go
@@ -1,0 +1,16 @@
+package purge
+
+import (
+	"log/slog"
+
+	"github.com/defektive/xodbox/pkg/xlog"
+)
+
+var pkgLogger *slog.Logger
+
+func lg() *slog.Logger {
+	if pkgLogger == nil {
+		pkgLogger = xlog.Get()
+	}
+	return pkgLogger
+}

--- a/pkg/workers/purge/worker.go
+++ b/pkg/workers/purge/worker.go
@@ -1,0 +1,41 @@
+package purge
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/defektive/xodbox/pkg/model"
+	"github.com/defektive/xodbox/pkg/types"
+)
+
+type Worker struct {
+	schedule   string
+	maxAgeDays int
+}
+
+func NewWorker(cfg map[string]string) types.Worker {
+	schedule := cfg["schedule"]
+	if schedule == "" {
+		schedule = "@daily"
+	}
+	days := 30
+	if v := cfg["max_age_days"]; v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			days = n
+		}
+	}
+	return &Worker{schedule: schedule, maxAgeDays: days}
+}
+
+func (w *Worker) Name() string     { return "purge" }
+func (w *Worker) Schedule() string { return w.schedule }
+
+func (w *Worker) Run(ctx context.Context) error {
+	n, err := model.PurgeInteractionsOlderThan(w.maxAgeDays)
+	if err != nil {
+		lg().Error("purge run failed", "err", err)
+		return err
+	}
+	lg().Info("purge complete", "deleted", n, "max_age_days", w.maxAgeDays)
+	return nil
+}

--- a/pkg/xodbox/config.go
+++ b/pkg/xodbox/config.go
@@ -14,7 +14,9 @@ import (
 	"github.com/defektive/xodbox/pkg/notifiers/app_log"
 	"github.com/defektive/xodbox/pkg/notifiers/discord"
 	"github.com/defektive/xodbox/pkg/notifiers/slack"
+	"github.com/defektive/xodbox/pkg/notifiers/webhook"
 	"github.com/defektive/xodbox/pkg/types"
+	"github.com/defektive/xodbox/pkg/workers/purge"
 	"gopkg.in/yaml.v3"
 )
 
@@ -26,6 +28,7 @@ type Config struct {
 	TemplateData map[string]string `yaml:"template_data"`
 	Handlers     []types.Handler
 	Notifiers    []types.Notifier
+	Workers      []types.Worker
 }
 
 // ConfigFile defines th structure of the YAML config files
@@ -34,6 +37,7 @@ type ConfigFile struct {
 	Defaults  map[string]string   `yaml:"defaults"`
 	Handlers  []map[string]string `yaml:"handlers"`
 	Notifiers []map[string]string `yaml:"notifiers"`
+	Workers   []map[string]string `yaml:"workers"`
 }
 
 // ToConfig creates a Config struct based on the ConfigFile
@@ -47,7 +51,7 @@ func (conf *ConfigFile) ToConfig() *Config {
 		}
 	}
 
-	appConfig := &Config{conf.Defaults, []types.Handler{}, []types.Notifier{}}
+	appConfig := &Config{conf.Defaults, []types.Handler{}, []types.Notifier{}, []types.Worker{}}
 
 	for _, handlerConfig := range conf.Handlers {
 		if newHandlerFn, ok := newHandlerMap[handlerConfig["handler"]]; ok {
@@ -64,6 +68,15 @@ func (conf *ConfigFile) ToConfig() *Config {
 			lg().Error("notifier not found", "notifier", notifierConfig["notifier"])
 		}
 	}
+
+	for _, workerConfig := range conf.Workers {
+		if newWorkerFn, ok := newWorkerMap[workerConfig["worker"]]; ok {
+			appConfig.Workers = append(appConfig.Workers, newWorkerFn(workerConfig))
+		} else {
+			lg().Error("worker not found", "worker", workerConfig["worker"])
+		}
+	}
+
 	return appConfig
 }
 
@@ -101,6 +114,7 @@ func configFromFile(configFile string) (*ConfigFile, error) {
 
 var newHandlerMap = map[string]func(handlerConfig map[string]string) types.Handler{}
 var newNotifierMap = map[string]func(notifierConfig map[string]string) types.Notifier{}
+var newWorkerMap = map[string]func(workerConfig map[string]string) types.Worker{}
 
 func init() {
 	newHandlerMap["DNS"] = dns.NewHandler
@@ -114,4 +128,7 @@ func init() {
 	newNotifierMap["app_log"] = app_log.NewNotifier
 	newNotifierMap["discord"] = discord.NewNotifier
 	newNotifierMap["slack"] = slack.NewNotifier
+	newNotifierMap["webhook"] = webhook.NewNotifierFromConfig
+
+	newWorkerMap["purge"] = purge.NewWorker
 }

--- a/pkg/xodbox/config/xodbox.yaml
+++ b/pkg/xodbox/config/xodbox.yaml
@@ -64,4 +64,14 @@ notifiers:
 #    author: PirateVirus
 #    author_image: https://s3-us-west-2.amazonaws.com/slack-f...72.png
 #    filter: "^HTTPX (GET|POST|HEAD|DELETE|PUT|PATCH|TRACE) /x/" # regex vs "HANDLER ACTION DETAIL from IP" (e.g. "^SMB Auth", "^DNS (A|AAAA) .*\\.evil\\.com")
+  ## Docs: https://defektive.github.io/xodbox/docs/pkg/notifiers/webhook/
+#  - notifier: webhook
+#    url: https://n8n.myteam.internal/webhook/xodbox # any HTTP endpoint
+#    filter: "^SMB Auth" # regex vs "HANDLER ACTION DETAIL from IP"; omit to receive everything
   - notifier: app_log
+## Docs: https://defektive.github.io/xodbox/docs/pkg/workers/
+#workers:
+#  ## Docs: https://defektive.github.io/xodbox/docs/pkg/workers/purge/
+#  - worker: purge
+#    schedule: "@daily" # cron expression or @every interval (e.g. "@every 6h")
+#    max_age_days: "30" # delete interactions older than this many days

--- a/pkg/xodbox/config_test.go
+++ b/pkg/xodbox/config_test.go
@@ -49,6 +49,7 @@ func TestConfigFile_ToConfig(t *testing.T) {
 				Notifiers: []types.Notifier{app_log.NewNotifier(map[string]string{
 					"notifier": "app_log",
 				})},
+				Workers: []types.Worker{},
 			},
 		},
 	}

--- a/pkg/xodbox/run.go
+++ b/pkg/xodbox/run.go
@@ -44,6 +44,10 @@ func NewApp(config *Config) *App {
 		stop:                 make(chan struct{}),
 	}
 
+	if len(config.Workers) > 0 {
+		newApp.workerEngine = newWorkerEngine(config.Workers)
+	}
+
 	for _, notifier := range config.Notifiers {
 		lg().Debug("register notifier", "notifier", notifier.Name())
 		newApp.RegisterNotificationHandler(notifier)
@@ -77,12 +81,19 @@ type App struct {
 
 	// stop is closed once by Shutdown to unblock waitForEvents.
 	stop chan struct{}
+
+	// workerEngine runs periodic background jobs. Nil when no workers are configured.
+	workerEngine *workerEngine
 }
 
 func (x *App) Run() {
 	// The persister writes to the DB off the event loop so a slow/locked SQLite
 	// write never delays notifier delivery.
 	go x.runPersister()
+
+	if x.workerEngine != nil {
+		x.workerEngine.start()
+	}
 
 	for _, h := range x.appConfig.Handlers {
 		lg().Debug("Running handler", "handler", h)
@@ -118,6 +129,10 @@ func (x *App) Shutdown() {
 		if err := h.Stop(ctx); err != nil {
 			lg().Warn("handler stop returned error", "handler", h.Name(), "err", err)
 		}
+	}
+
+	if x.workerEngine != nil {
+		x.workerEngine.stop()
 	}
 
 	// Close stop at most once so concurrent Shutdown callers don't

--- a/pkg/xodbox/worker_engine.go
+++ b/pkg/xodbox/worker_engine.go
@@ -1,0 +1,61 @@
+package xodbox
+
+import (
+	"context"
+
+	"github.com/defektive/xodbox/pkg/types"
+	"github.com/robfig/cron/v3"
+)
+
+// workerEngine manages the lifecycle of all configured Workers using a
+// robfig/cron scheduler. It is created by NewApp and driven by Run/Shutdown.
+type workerEngine struct {
+	workers []types.Worker
+	cron    *cron.Cron
+	cancel  context.CancelFunc
+}
+
+func newWorkerEngine(workers []types.Worker) *workerEngine {
+	return &workerEngine{
+		workers: workers,
+		// SkipIfStillRunning: if a tick fires while a prior run is still
+		// executing, the new tick is silently dropped — prevents pileups for
+		// slow workers.
+		cron: cron.New(cron.WithChain(
+			cron.SkipIfStillRunning(cron.DefaultLogger),
+		)),
+	}
+}
+
+func (we *workerEngine) start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	we.cancel = cancel
+
+	for _, w := range we.workers {
+		w := w
+		if _, err := we.cron.AddFunc(w.Schedule(), func() {
+			if err := w.Run(ctx); err != nil {
+				lg().Error("worker run error", "worker", w.Name(), "err", err)
+			}
+		}); err != nil {
+			lg().Error("failed to register worker schedule",
+				"worker", w.Name(), "schedule", w.Schedule(), "err", err)
+		} else {
+			lg().Info("worker registered", "worker", w.Name(), "schedule", w.Schedule())
+		}
+	}
+
+	we.cron.Start()
+	lg().Info("worker engine started", "count", len(we.workers))
+}
+
+func (we *workerEngine) stop() {
+	if we.cancel != nil {
+		we.cancel()
+	}
+	// cron.Stop() prevents new ticks and returns a context that is Done once
+	// all currently-executing jobs return.
+	stopCtx := we.cron.Stop()
+	<-stopCtx.Done()
+	lg().Info("worker engine stopped")
+}


### PR DESCRIPTION
## Summary

Introduces a worker engine that manages periodic background jobs using the robfig/cron scheduler. This enables xodbox to run scheduled maintenance tasks like data purging without blocking the main event loop.

## Key Changes

- **Worker interface** (`pkg/types/interfaces.go`): New `Worker` interface for periodic background jobs with `Name()`, `Schedule()` (cron expression), and `Run(ctx)` methods.
- **Worker engine** (`pkg/xodbox/worker_engine.go`): Manages worker lifecycle using robfig/cron v3 with `SkipIfStillRunning` chain to prevent job pileups. Started/stopped alongside the app.
- **Purge worker** (`pkg/workers/purge/`): First worker implementation that deletes interactions older than a configurable number of days (default 30). Scheduled via `@daily` by default.
- **Config integration** (`pkg/xodbox/config.go`): Added `Workers` field to `Config` and `ConfigFile`, registered purge worker in `newWorkerMap`, and wired worker instantiation from YAML.
- **App lifecycle** (`pkg/xodbox/run.go`): Worker engine started in `Run()` and stopped in `Shutdown()` with graceful drain.
- **Database helper** (`pkg/model/interactions.go`): Added `PurgeInteractionsOlderThan()` to safely delete old interactions with validation.
- **Webhook notifier** (`pkg/notifiers/webhook/notifier.go`): Added `NewNotifierFromConfig()` factory for YAML-driven instantiation (consistency with other notifiers).

## Implementation Details

- Workers run in their own goroutine managed by cron; errors are logged but don't stop future ticks.
- Context cancellation on shutdown ensures graceful termination of in-flight jobs.
- Follows existing package conventions: package-local `logging.go` with `lg()` helper, config-first design, and registration pattern matching handlers/notifiers.
- Purge worker validates `max_age_days >= 1` to prevent accidental data loss.

https://claude.ai/code/session_0178tQbcDw6y34RmxRn1RjUN