### PR TITLE
Pretty-print JSON in event details and webhook notifications

### DIFF
--- a/pkg/handlers/httpx/_index.md
+++ b/pkg/handlers/httpx/_index.md
@@ -138,7 +138,8 @@ JSON admin API. It lets an operator log in and:
   smb), so the log spans all protocols, not just HTTP,
 - **delete** individual events (and their uploaded files) from the list or
   detail view, and delete individual uploaded files without removing the event,
-- inspect an **event's detail** with a one-click **copy-as-curl**,
+- inspect an **event's detail** with a one-click **copy-as-curl** — JSON
+  bodies are automatically pretty-printed for readability,
 - get a **webhook-style view** of every hit to a specific `target` path,
 - watch the **Events** log and **sink** feeds update in **real time** — new
   interactions stream in live via Server-Sent Events (`GET /api/stream`,

--- a/pkg/handlers/httpx/admin_api.go
+++ b/pkg/handlers/httpx/admin_api.go
@@ -1,7 +1,9 @@
 package httpx
 
 import (
+	"bytes"
 	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"time"
@@ -81,16 +83,34 @@ func safeBodyString(data []byte) (string, bool) {
 		return "", false
 	}
 	if utf8.Valid(data) {
+		s := string(data)
 		if len(data) > maxBodyDisplay {
-			return string(data[:maxBodyDisplay]) + "\n[truncated — download full body via the Files tab]", false
+			s = string(data[:maxBodyDisplay]) + "\n[truncated — download full body via the Files tab]"
 		}
-		return string(data), false
+		return tryPrettyJSON(s), false
 	}
 	preview := data
 	if len(preview) > 512 {
 		preview = preview[:512]
 	}
 	return hex.Dump(preview) + "\n[binary body — download via the Files tab]", true
+}
+
+// tryPrettyJSON attempts to pretty-print s as JSON. If s is not valid JSON,
+// it is returned unchanged.
+func tryPrettyJSON(s string) string {
+	trimmed := bytes.TrimSpace([]byte(s))
+	if len(trimmed) == 0 {
+		return s
+	}
+	if trimmed[0] != '{' && trimmed[0] != '[' {
+		return s
+	}
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, trimmed, "", "  "); err != nil {
+		return s
+	}
+	return buf.String()
 }
 
 func (a *adminAuth) handleInteractions(w http.ResponseWriter, r *http.Request) {

--- a/pkg/handlers/httpx/admin_api_test.go
+++ b/pkg/handlers/httpx/admin_api_test.go
@@ -113,6 +113,31 @@ func TestInteractionsRequireAuth(t *testing.T) {
 	resp.Body.Close()
 }
 
+func TestSafeBodyStringPrettyPrintsJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"object", `{"a":1,"b":"c"}`, "{\n  \"a\": 1,\n  \"b\": \"c\"\n}"},
+		{"array", `[1,2,3]`, "[\n  1,\n  2,\n  3\n]"},
+		{"not json", `hello world`, `hello world`},
+		{"empty", ``, ``},
+		{"html", `<html>`, `<html>`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, isBin := safeBodyString([]byte(tc.in))
+			if isBin {
+				t.Fatal("unexpected binary flag")
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestInteractionNotFound(t *testing.T) {
 	srv, _, u := adminTestServer(t)
 	full, _, _ := model.NewAPIKey(u.ID, "k", nil)

--- a/pkg/notifiers/webhook/chattext_test.go
+++ b/pkg/notifiers/webhook/chattext_test.go
@@ -35,6 +35,23 @@ func TestChatTextOmitsCurlForPlainEvents(t *testing.T) {
 	}
 }
 
+func TestChatTextPrettyPrintsJSON(t *testing.T) {
+	e := &types.BaseEvent{RawData: []byte(`{"a":1,"b":"c"}`)}
+	txt := ChatText(e)
+	if !strings.Contains(txt, "\"a\": 1") {
+		t.Errorf("expected pretty-printed JSON:\n%s", txt)
+	}
+}
+
+func TestChatTextLeavesNonJSONAlone(t *testing.T) {
+	raw := "GET /foo HTTP/1.1\r\nHost: bar\r\n\r\n"
+	e := &types.BaseEvent{RawData: []byte(raw)}
+	txt := ChatText(e)
+	if strings.Contains(txt, "  ") && !strings.Contains(txt, raw) {
+		t.Errorf("non-JSON data should not be modified:\n%s", txt)
+	}
+}
+
 func TestJSONPayloadCurlOmitemptyForPlainEvents(t *testing.T) {
 	n := NewNotifier("http://example", "")
 	b, err := n.Payload(&types.BaseEvent{RawData: []byte("x")})

--- a/pkg/notifiers/webhook/notifier.go
+++ b/pkg/notifiers/webhook/notifier.go
@@ -208,12 +208,32 @@ func ChatText(e types.InteractionEvent) string {
 	data := e.Data()
 	if isBinary(data) {
 		data = fmt.Sprintf("(%d bytes of binary data)", len(data))
+	} else {
+		data = tryPrettyJSON(data)
 	}
 	sb.WriteString(fmt.Sprintf("%s\n```%s\n```", e.Details(), data))
 	if curl := CurlCommand(e); curl != "" {
 		sb.WriteString(fmt.Sprintf("\nReplay:\n```%s\n```", curl))
 	}
 	return sb.String()
+}
+
+// tryPrettyJSON attempts to pretty-print s as JSON. If s is not valid JSON
+// (or contains non-JSON content like HTTP headers prepended), it is returned
+// unchanged.
+func tryPrettyJSON(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if len(trimmed) == 0 {
+		return s
+	}
+	if trimmed[0] != '{' && trimmed[0] != '[' {
+		return s
+	}
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, []byte(trimmed), "", "  "); err != nil {
+		return s
+	}
+	return buf.String()
 }
 
 // sinkInfo extracts sink metadata from a SinkHitProvider event, or nil.


### PR DESCRIPTION
## Summary

Add automatic pretty-printing of JSON request/response bodies in the admin API event detail view and webhook notifications. Non-JSON content is left unchanged, improving readability without breaking existing behavior.

## Changes

- **Admin API (`pkg/handlers/httpx/admin_api.go`)**:
  - Add `tryPrettyJSON()` helper that attempts to indent JSON with 2-space formatting
  - Modify `safeBodyString()` to call `tryPrettyJSON()` on valid UTF-8 text bodies
  - Falls back gracefully to original content if JSON parsing fails

- **Webhook notifier (`pkg/notifiers/webhook/notifier.go`)**:
  - Add `tryPrettyJSON()` helper (similar implementation using `strings.TrimSpace`)
  - Update `ChatText()` to pretty-print JSON data in webhook payloads
  - Non-JSON content (e.g., HTTP headers, binary data) is unaffected

- **Tests**:
  - Add `TestSafeBodyStringPrettyPrintsJSON()` covering JSON objects, arrays, non-JSON text, empty strings, and HTML
  - Add `TestChatTextPrettyPrintsJSON()` and `TestChatTextLeavesNonJSONAlone()` for webhook behavior

- **Documentation (`pkg/handlers/httpx/_index.md`)**:
  - Update admin API feature description to note that JSON bodies are automatically pretty-printed

## Implementation Details

Both `tryPrettyJSON()` implementations:
- Check if content starts with `{` or `[` (after trimming whitespace) to avoid attempting JSON parsing on non-JSON text
- Use `json.Indent()` with 2-space indentation for consistent formatting
- Return original content unchanged if indentation fails or content is empty/non-JSON
- Preserve truncation messages and binary data handling in the admin API flow

https://claude.ai/code/session_01UGqdb9bKjvPyPk7aitjViP