### PR TITLE
Upgrade CodeQL action to v4.37.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,6 +96,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary
Updates the GitHub CodeQL action to the latest version (v4.37.1) to benefit from the latest security analysis improvements and bug fixes.

## Changes
- Updated `github/codeql-action/analyze` from v4.36.3 to v4.37.1
  - Hash: `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a` → `7188fc363630916deb702c7fdcf4e481b751f97a`

## Notes
This is a routine dependency update for the CI/CD pipeline. No functional changes to the codebase itself.

https://claude.ai/code/session_01WSMs11etQt7iYrUXA6Kf7E